### PR TITLE
mgym upload: Mirror Circuits N8D64 on IQM/Garnet

### DIFF
--- a/metriq-gym/v0.4/aws/results.json
+++ b/metriq-gym/v0.4/aws/results.json
@@ -1,5 +1,44 @@
 [
   {
+    "app_version": "0.4.2.dev17+gd000fa179",
+    "timestamp": "2025-11-04T17:12:58.470091",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "values": {
+        "success_probability": 0.7853,
+        "polarization": 0.7844580392156862,
+        "binary_success": 1.0
+      },
+      "uncertainties": {
+        "success_probability": 0.004106140645423632,
+        "polarization": 0.004122243157758627,
+        "binary_success": null
+      },
+      "directions": {
+        "success_probability": "higher",
+        "polarization": "higher"
+      }
+    },
+    "platform": {
+      "device": "iqm_garnet",
+      "device_metadata": {
+        "num_qubits": 20,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 64,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 8
+    }
+  },
+  {
     "app_version": "0.4.2.dev12+g1310c034e.d20251021",
     "timestamp": "2025-10-22T10:45:42.863427",
     "suite_id": null,


### PR DESCRIPTION
As a sanity check, I evaluated the compiled OpenQASM circuit from AWS:

<img width="1958" height="830" alt="image" src="https://github.com/user-attachments/assets/9c1eedba-6c9a-48d2-a834-1cad2f60bfad" />

With width = 8, a brick layer alternates between 4 disjoint pairs (0–1,2–3,4–5,6–7) and 3 pairs (1–2,3–4,5–6); average available pairs per layer ≈ 3.5; With two_qubit_gate_prob = 0.5, expected forward CNOTs per layer ≈ 3.5 × 0.5 = 1.75.

Mirror circuits include the inverse of the forward part, so we roughly double that: ≈ 3.5 CNOTs per (forward+mirror) layer.

For num_layers = 64, expected CNOTs per circuit ≈ 64 × 3.5 ≈ 224, which matches with the 220 2q gates in the circuit file.