### PR TITLE
mgym upload: Mirror Circuits N8D64 on IQM/Emerald  

### DIFF
--- a/metriq-gym/v0.4/aws/results.json
+++ b/metriq-gym/v0.4/aws/results.json
@@ -1,5 +1,44 @@
 [
   {
+    "app_version": "0.4.2.dev17+gd000fa179",
+    "timestamp": "2025-11-04T17:40:47.484296",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "values": {
+        "success_probability": 0.7774,
+        "polarization": 0.7765270588235293,
+        "binary_success": 1.0
+      },
+      "uncertainties": {
+        "success_probability": 0.004159918749206528,
+        "polarization": 0.004176232156066161,
+        "binary_success": null
+      },
+      "directions": {
+        "success_probability": "higher",
+        "polarization": "higher"
+      }
+    },
+    "platform": {
+      "device": "iqm_emerald",
+      "device_metadata": {
+        "num_qubits": 54,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 64,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 8
+    }
+  },
+  {
     "app_version": "0.4.2.dev12+g1310c034e.d20251021",
     "timestamp": "2025-10-22T10:45:42.863427",
     "suite_id": null,


### PR DESCRIPTION
Similarly as the Gernet case, I did a sanity check on (one of the ten) circuit run on AWS: 

<img width="1966" height="812" alt="image" src="https://github.com/user-attachments/assets/ee0a2cc3-1f63-4df2-a49c-9f1af707e76a" />
