### PR TITLE
mgym upload: QML Kernel on quantinuum/H2-2

### DIFF
--- a/metriq-gym/v0.5/quantinuum/h2-2/2025-12-08_09-12-33_qml_kernel_405f0624.json
+++ b/metriq-gym/v0.5/quantinuum/h2-2/2025-12-08_09-12-33_qml_kernel_405f0624.json
@@ -1,0 +1,31 @@
+[
+  {
+    "app_version": "0.4.3.dev12+g1b4196a92",
+    "timestamp": "2025-12-08T09:12:33.014537",
+    "suite_id": null,
+    "job_type": "QML Kernel",
+    "results": {
+      "accuracy_score": {
+        "value": 0.913,
+        "uncertainty": 0.008912407082264588
+      },
+      "score": {
+        "value": 0.913,
+        "uncertainty": 0.008912407082264588
+      }
+    },
+    "platform": {
+      "device": "H2-2",
+      "device_metadata": {
+        "simulator": false,
+        "version": "0.54.0"
+      },
+      "provider": "quantinuum"
+    },
+    "params": {
+      "benchmark_name": "QML Kernel",
+      "num_qubits": 20,
+      "shots": 1000
+    }
+  }
+]


### PR DESCRIPTION
Replaces #114 
```
{'benchmark_name': 'QML Kernel', 'num_qubits': 20, 'shots': 1000}
```