### PR TITLE
Add CLOPS and fix EPLG in scoring rubric

### DIFF
--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -101,6 +101,29 @@ def path_version_segment(path: str, root: str) -> str:
     return "unknown"
 
 
+def _inject_default_metric_directions(out: dict[str, Any], row: dict[str, Any]) -> None:
+    """Inject known metric directions when source payload omits them."""
+    params = row.get("params") if isinstance(row.get("params"), dict) else {}
+    bench = params.get("benchmark_name") if isinstance(params.get("benchmark_name"), str) else None
+    if bench is None and isinstance(row.get("job_type"), str):
+        bench = row.get("job_type")
+
+    if bench != "EPLG":
+        return
+
+    results = out.get("results") if isinstance(out.get("results"), dict) else None
+    if results is None:
+        return
+
+    existing = out.get("directions") if isinstance(out.get("directions"), dict) else {}
+    directions = dict(existing)
+    for metric in ("score", "eplg_10", "eplg_20", "eplg_50", "eplg_100"):
+        if metric in results and metric not in directions:
+            directions[metric] = "lower"
+    if directions:
+        out["directions"] = directions
+
+
 def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k in ("app_version", "timestamp", "provider", "suite_id", "device", "job_type", "results", "params"):
@@ -139,6 +162,7 @@ def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
             out["results"] = values
             if uncertainties:
                 out["errors"] = uncertainties
+            _inject_default_metric_directions(out, row)
             return out
 
         values = r.get("values") if isinstance(r.get("values"), dict) else None
@@ -153,6 +177,7 @@ def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
         else:
             out["results"] = r
 
+    _inject_default_metric_directions(out, row)
     return out
 
 
@@ -350,8 +375,11 @@ def collect_flat_rows_and_registry(root: str, files: list[str]) -> tuple[
             print(f"Warning: failed to load {src}: {e}", file=sys.stderr)
             continue
 
-        if not isinstance(data, list):
-            print(f"Warning: skipping {src} (not a list)", file=sys.stderr)
+        if isinstance(data, dict):
+            # Accept singleton result payloads by normalizing to a one-item list.
+            data = [data]
+        elif not isinstance(data, list):
+            print(f"Warning: skipping {src} (not a list/object)", file=sys.stderr)
             continue
 
         for row in data:

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -550,10 +550,29 @@ def compute_and_attach_metriq_scores(
         # This preserves all computed normalized metrics even for multi-metric benchmarks.
         r["normalized_scores"] = scores
 
-        # Choose a scalar metriq_score when possible:
-        #  - If exactly one configured metric applies to this row, expose it as metriq_score
+        # Expose a scalar metriq_score:
+        #  - single-metric rows map directly
+        #  - multi-metric rows use weighted average by component effective weights
         if len(scores) == 1:
             r["metriq_score"] = next(iter(scores.values()))
+        else:
+            weighted_sum = 0.0
+            weight_total = 0.0
+            for metric, metric_score in scores.items():
+                comp = metric_to_comp.get(metric, {})
+                w_raw = comp.get("_effective_weight", comp.get("weight", 0.0))
+                try:
+                    weight = float(w_raw)
+                except Exception:
+                    weight = 0.0
+                if not (weight == weight) or weight in (float("inf"), float("-inf")) or weight < 0:
+                    weight = 0.0
+                if weight == 0.0:
+                    continue
+                weighted_sum += weight * metric_score
+                weight_total += weight
+            if weight_total > 0.0:
+                r["metriq_score"] = weighted_sum / weight_total
 
 
 def load_scoring_config(root: str) -> dict[str, Any]:

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -380,25 +380,25 @@
             {
               "benchmark": "EPLG",
               "metric": "eplg_10",
-              "label": "EPLG-10:score",
+              "label": "EPLG-10",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_20",
-              "label": "EPLG-20:score",
+              "label": "EPLG-20",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_50",
-              "label": "EPLG-50:score",
+              "label": "EPLG-50",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_100",
-              "label": "EPLG-100:score",
+              "label": "EPLG-100",
               "weight": "1/4"
             }
           ]

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -169,31 +169,40 @@
             "components": [
               {
                 "benchmark": "EPLG",
-                "metric": "score",
-                "selector": { "num_qubits": 10 },
+                "metric": "eplg_10",
                 "label": "EPLG-10:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
-                "metric": "score",
-                "selector": { "num_qubits": 20 },
+                "metric": "eplg_20",
                 "label": "EPLG-20:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
-                "metric": "score",
-                "selector": { "num_qubits": 50 },
+                "metric": "eplg_50",
                 "label": "EPLG-50:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
-                "metric": "score",
-                "selector": { "num_qubits": 100 },
+                "metric": "eplg_100",
                 "label": "EPLG-100:score",
                 "weight": "1/4"
+              }
+            ]
+          },
+          {
+            "label": "CLOPS",
+            "weight": "0/1",
+            "components": [
+              {
+                "benchmark": "CLOPS",
+                "metric": "score",
+                "selector": { "mode": "twirled", "use_session": true },
+                "label": "CLOPS (twirled, session=true):score",
+                "weight": "1/1"
               }
             ]
           }
@@ -210,7 +219,7 @@
       "components": [
         {
           "label": "BSEQ",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "BSEQ",
@@ -225,7 +234,7 @@
         },
         {
           "label": "QML Kernel",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "QML Kernel",
@@ -259,7 +268,7 @@
         },
         {
           "label": "Mirror Circuits",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "Mirror Circuits",
@@ -307,7 +316,7 @@
         },
         {
           "label": "WIT",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "WIT",
@@ -320,7 +329,7 @@
         },
         {
           "label": "Quantum Fourier Transform",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "Quantum Fourier Transform",
@@ -332,7 +341,7 @@
         },
         {
           "label": "Linear Ramp QAOA",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "Linear Ramp QAOA",
@@ -366,35 +375,44 @@
         },
         {
           "label": "EPLG",
-          "weight": "1/7",
+          "weight": "1/8",
           "components": [
             {
               "benchmark": "EPLG",
-              "metric": "score",
-              "selector": { "num_qubits": 10 },
+              "metric": "eplg_10",
               "label": "EPLG-10:score",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
-              "metric": "score",
-              "selector": { "num_qubits": 20 },
+              "metric": "eplg_20",
               "label": "EPLG-20:score",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
-              "metric": "score",
-              "selector": { "num_qubits": 50 },
+              "metric": "eplg_50",
               "label": "EPLG-50:score",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
-              "metric": "score",
-              "selector": { "num_qubits": 100 },
+              "metric": "eplg_100",
               "label": "EPLG-100:score",
               "weight": "1/4"
+            }
+          ]
+        },
+        {
+          "label": "CLOPS",
+          "weight": "1/8",
+          "components": [
+            {
+              "benchmark": "CLOPS",
+              "metric": "score",
+              "selector": { "mode": "twirled", "use_session": true },
+              "label": "CLOPS (twirled, session=true):score",
+              "weight": "1/1"
             }
           ]
         }


### PR DESCRIPTION
The main file to look at is scripts/scoring.json. The rest is fixes to allow for inverse direction of the metrics (recall that EPLG is 'the lower the better') 