### PR TITLE
Normalize name of retired OriginQ devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example `scripts/scoring.json`:
 {
   "series": {
     "v0.4": {
-      "baseline": { "provider": "origin", "device": "origin_wukong" },
+      "baseline": { "provider": "origin", "device": "wukong_102" },
       "composite": {
         "components": [
           {

--- a/metriq-gym/v0.4/origin/results.json
+++ b/metriq-gym/v0.4/origin/results.json
@@ -19,7 +19,7 @@
       }
     },
     "platform": {
-      "device": "72",
+      "device": "wukong_72",
       "device_metadata": {
         "num_qubits": 72,
         "simulator": false
@@ -46,7 +46,7 @@
       "score": 0.026
     },
     "platform": {
-      "device": "72",
+      "device": "wukong_72",
       "device_metadata": {
         "num_qubits": 72,
         "simulator": false
@@ -76,7 +76,7 @@
       }
     },
     "platform": {
-      "device": "origin_wukong",
+      "device": "wukong_102",
       "device_metadata": {
         "num_qubits": 102,
         "simulator": false

--- a/metriq-gym/v0.4/origin/wukong_72/2025-12-11_14-36-51_quantum_fourier_transform_d32054dd.json
+++ b/metriq-gym/v0.4/origin/wukong_72/2025-12-11_14-36-51_quantum_fourier_transform_d32054dd.json
@@ -1,21 +1,21 @@
 [
   {
-    "app_version": "0.5.1a1.dev6+gea73bf450",
-    "timestamp": "2026-01-06T15:37:51.976973",
+    "app_version": "0.4.3.dev23+g6d5a875ad",
+    "timestamp": "2025-12-11T14:36:51.522552",
     "suite_id": null,
     "job_type": "Quantum Fourier Transform",
     "results": {
       "accuracy_score": {
-        "value": 0.005,
-        "uncertainty": 0.0069282032302755096
+        "value": 0.12400000000000001,
+        "uncertainty": 0.0712614903015647
       },
       "score": {
-        "value": 0.005,
-        "uncertainty": 0.0069282032302755096
+        "value": 0.12400000000000001,
+        "uncertainty": 0.0712614903015647
       }
     },
     "platform": {
-      "device": "72",
+      "device": "wukong_72",
       "device_metadata": {
         "num_qubits": 72,
         "simulator": false
@@ -25,11 +25,11 @@
     "params": {
       "benchmark_name": "Quantum Fourier Transform",
       "max_circuits": 3,
-      "max_qubits": 12,
+      "max_qubits": 6,
       "method": 1,
-      "min_qubits": 4,
+      "min_qubits": 2,
       "shots": 1000,
-      "skip_qubits": 4,
+      "skip_qubits": 1,
       "use_midcircuit_measurement": false
     }
   }

--- a/metriq-gym/v0.5/origin/wk_c102-2/2026-01-07_07-27-14_quantum_fourier_transform_88551529.json
+++ b/metriq-gym/v0.5/origin/wk_c102-2/2026-01-07_07-27-14_quantum_fourier_transform_88551529.json
@@ -15,7 +15,7 @@
       }
     },
     "platform": {
-      "device": "WK_C102-2",
+      "device": "wukong_102",
       "device_metadata": {
         "num_qubits": 102,
         "simulator": false

--- a/metriq-gym/v0.5/origin/wk_c102-2/2026-01-07_09-55-41_bseq_729f9500.json
+++ b/metriq-gym/v0.5/origin/wk_c102-2/2026-01-07_09-55-41_bseq_729f9500.json
@@ -13,7 +13,7 @@
       }
     },
     "platform": {
-      "device": "WK_C102-2",
+      "device": "wukong_102",
       "device_metadata": {
         "num_qubits": 102,
         "simulator": false

--- a/metriq-gym/v0.5/origin/wk_c102-2/2026-01-16_09-08-51_mirror_circuits_db321a98.json
+++ b/metriq-gym/v0.5/origin/wk_c102-2/2026-01-16_09-08-51_mirror_circuits_db321a98.json
@@ -20,7 +20,7 @@
       }
     },
     "platform": {
-      "device": "WK_C102-2",
+      "device": "wukong_102",
       "device_metadata": {
         "num_qubits": 102,
         "simulator": false

--- a/metriq-gym/v0.5/origin/wk_c102-2/2026-01-16_09-11-43_mirror_circuits_32b5fe15.json
+++ b/metriq-gym/v0.5/origin/wk_c102-2/2026-01-16_09-11-43_mirror_circuits_32b5fe15.json
@@ -20,7 +20,7 @@
       }
     },
     "platform": {
-      "device": "WK_C102-2",
+      "device": "wukong_102",
       "device_metadata": {
         "num_qubits": 102,
         "simulator": false

--- a/metriq-gym/v0.5/origin/wukong_72/2026-01-06_15-37-51_quantum_fourier_transform_2bd3028c.json
+++ b/metriq-gym/v0.5/origin/wukong_72/2026-01-06_15-37-51_quantum_fourier_transform_2bd3028c.json
@@ -1,21 +1,21 @@
 [
   {
-    "app_version": "0.4.3.dev23+g6d5a875ad",
-    "timestamp": "2025-12-11T14:36:51.522552",
+    "app_version": "0.5.1a1.dev6+gea73bf450",
+    "timestamp": "2026-01-06T15:37:51.976973",
     "suite_id": null,
     "job_type": "Quantum Fourier Transform",
     "results": {
       "accuracy_score": {
-        "value": 0.12400000000000001,
-        "uncertainty": 0.0712614903015647
+        "value": 0.005,
+        "uncertainty": 0.0069282032302755096
       },
       "score": {
-        "value": 0.12400000000000001,
-        "uncertainty": 0.0712614903015647
+        "value": 0.005,
+        "uncertainty": 0.0069282032302755096
       }
     },
     "platform": {
-      "device": "72",
+      "device": "wukong_72",
       "device_metadata": {
         "num_qubits": 72,
         "simulator": false
@@ -25,11 +25,11 @@
     "params": {
       "benchmark_name": "Quantum Fourier Transform",
       "max_circuits": 3,
-      "max_qubits": 6,
+      "max_qubits": 12,
       "method": 1,
-      "min_qubits": 2,
+      "min_qubits": 4,
       "shots": 1000,
-      "skip_qubits": 1,
+      "skip_qubits": 4,
       "use_midcircuit_measurement": false
     }
   }

--- a/metriq-gym/v0.5/origin/wukong_72/2026-01-06_15-58-25_linear_ramp_qaoa_450f6cb1.json
+++ b/metriq-gym/v0.5/origin/wukong_72/2026-01-06_15-58-25_linear_ramp_qaoa_450f6cb1.json
@@ -21,7 +21,7 @@
       }
     },
     "platform": {
-      "device": "72",
+      "device": "wukong_72",
       "device_metadata": {
         "num_qubits": 72,
         "simulator": false


### PR DESCRIPTION
72-qubit and 102-qubit  OriginQ devices have officially been retired.
When we collected benchmark values for them, their backend names were inconsistent across runs, so this PR normalize the name, for ease of future identification. 