### PR TITLE
Curated platform catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ Example `scripts/scoring.json`:
 Baselines are computed per major series (e.g., all `v0.x.y` share one baseline reference),
 using the latest available baseline row per `(benchmark, metric, selector)` key.
 
+### Curated platform catalog
+
+Edit `scripts/platform_catalog.json` to add curated metadata for platforms that should carry
+extra status on the website.
+
+```json
+{
+  "platforms": [
+    {
+      "provider": "ibm",
+      "device": "ibm_brisbane",
+      "aliases": ["brisbane"],
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2025-11-03"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- `device` is the canonical device identifier for that provider.
+- `aliases` are optional same-provider aliases that should inherit the same catalog entry.
+- `lifecycle` is currently passed through into generated platform JSON for `metriq-web`.
+
+After editing the catalog, rerun `python3 scripts/aggregate.py`. The generated
+`dist/platforms/index.json` and `dist/platforms/<provider>/<device>.json` outputs will include
+the curated `lifecycle` block for matching platforms.
+
 ## Acknowledgements
 
 Some of these results used resources of the Oak Ridge Leadership Computing Facility, which is a DOE Office of Science User Facility supported under Contract DE-AC05-00OR22725.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ extra status on the website.
 Notes:
 
 - `device` is the canonical device identifier for that provider.
-- `aliases` are optional same-provider aliases that should inherit the same catalog entry.
-- `lifecycle` is currently passed through into generated platform JSON for `metriq-web`.
+- `aliases` (optional) lists same-provider aliases that should inherit the same curated catalog entry.
+- `lifecycle` (optional) describes curated platform status metadata, such as whether a device is retired and when that status took effect. It is currently the only curated field passed through into generated platform JSON for `metriq-web`.
 
 After editing the catalog, rerun `python3 scripts/aggregate.py`. The generated
 `dist/platforms/index.json` and `dist/platforms/<provider>/<device>.json` outputs will include

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -19,6 +19,7 @@ from etl import (
     ensure_dir,
     find_result_files,
     collect_flat_rows_and_registry,
+    load_platform_catalog,
     write_platform_outputs,
     write_benchmark_latest,
 )
@@ -42,6 +43,7 @@ def main(argv: list[str] | None = None) -> int:
     files = find_result_files(root)
     total_files = len(files)
     flat_rows, row_series, registry = collect_flat_rows_and_registry(root, files)
+    platform_catalog = load_platform_catalog(root)
     apply_custom_metric_derivations(flat_rows)
 
     # Scoring configured only via scripts/scoring.json
@@ -85,6 +87,7 @@ def main(argv: list[str] | None = None) -> int:
         dist_path,
         generated_at,
         composite_records,
+        platform_catalog,
     )
 
     print(

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -246,8 +246,6 @@ def load_platform_catalog(root: str) -> dict[tuple[str, str], dict[str, Any]]:
             continue
 
         lifecycle = _normalize_platform_lifecycle(entry.get("lifecycle"))
-        if lifecycle is None:
-            continue
 
         names = [device.strip()]
         aliases = entry.get("aliases")
@@ -256,7 +254,9 @@ def load_platform_catalog(root: str) -> dict[tuple[str, str], dict[str, Any]]:
                 if isinstance(alias, str) and alias.strip():
                     names.append(alias.strip())
 
-        payload = {"lifecycle": lifecycle}
+        payload: dict[str, Any] = {}
+        if lifecycle is not None:
+            payload["lifecycle"] = lifecycle
         for name in dict.fromkeys(names):
             key = (provider.strip(), name)
             existing = resolved.get(key)

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -192,6 +192,84 @@ def get_provider_device(row: dict[str, Any]) -> tuple[str | None, str | None]:
     return provider, device
 
 
+def _normalize_platform_lifecycle(lifecycle: Any) -> dict[str, str] | None:
+    if not isinstance(lifecycle, dict):
+        return None
+
+    normalized: dict[str, str] = {}
+    status = lifecycle.get("status")
+    effective_at = lifecycle.get("effective_at")
+    source_url = lifecycle.get("source_url")
+    source_label = lifecycle.get("source_label")
+
+    if isinstance(status, str) and status.strip():
+        normalized["status"] = status.strip()
+    if isinstance(effective_at, str) and effective_at.strip():
+        normalized["effective_at"] = effective_at.strip()
+    if isinstance(source_url, str) and source_url.strip():
+        normalized["source_url"] = source_url.strip()
+    if isinstance(source_label, str) and source_label.strip():
+        normalized["source_label"] = source_label.strip()
+
+    return normalized or None
+
+
+def load_platform_catalog(root: str) -> dict[tuple[str, str], dict[str, Any]]:
+    """Load curated platform metadata from scripts/platform_catalog.json.
+
+    The catalog is keyed by a canonical (provider, device) entry and may optionally
+    provide same-provider aliases that should inherit the same curated metadata.
+    """
+    catalog_path = os.path.join(root, "scripts", "platform_catalog.json")
+    try:
+        with open(catalog_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        print(f"Warning: failed to load platform catalog: {exc}", file=sys.stderr)
+        return {}
+
+    raw_platforms = data.get("platforms") if isinstance(data, dict) else None
+    if not isinstance(raw_platforms, list):
+        return {}
+
+    resolved: dict[tuple[str, str], dict[str, Any]] = {}
+    for entry in raw_platforms:
+        if not isinstance(entry, dict):
+            continue
+        provider = entry.get("provider")
+        device = entry.get("device")
+        if not isinstance(provider, str) or not provider.strip():
+            continue
+        if not isinstance(device, str) or not device.strip():
+            continue
+
+        lifecycle = _normalize_platform_lifecycle(entry.get("lifecycle"))
+        if lifecycle is None:
+            continue
+
+        names = [device.strip()]
+        aliases = entry.get("aliases")
+        if isinstance(aliases, list):
+            for alias in aliases:
+                if isinstance(alias, str) and alias.strip():
+                    names.append(alias.strip())
+
+        payload = {"lifecycle": lifecycle}
+        for name in dict.fromkeys(names):
+            key = (provider.strip(), name)
+            existing = resolved.get(key)
+            if existing is not None and existing != payload:
+                print(
+                    f"Warning: duplicate platform catalog entry for {provider}/{name}; using last entry",
+                    file=sys.stderr,
+                )
+            resolved[key] = payload
+
+    return resolved
+
+
 # ---------------------------- Platform Registry ----------------------------
 
 PlatformKey = tuple[str, str]
@@ -282,10 +360,12 @@ def write_platform_outputs(
     dist_path: str,
     generated_at: str,
     composite_records: list[dict[str, Any]] | None = None,
+    platform_catalog: dict[PlatformKey, dict[str, Any]] | None = None,
 ) -> tuple[int, str]:
     platforms_dir = os.path.join(dist_path, "platforms")
     ensure_dir(platforms_dir)
     index_platforms: list[dict[str, Any]] = []
+    platform_catalog = platform_catalog or {}
 
     # Optional mapping from (provider, device) -> composite score record
     composite_map: dict[PlatformKey, dict[str, Any]] = {}
@@ -320,6 +400,7 @@ def write_platform_outputs(
             "current": current,
             "history": history_list,
         }
+        platform_payload.update(platform_catalog.get((provider, device), {}))
 
         comp_rec = composite_map.get((provider, device))
         if comp_rec is not None:
@@ -340,6 +421,7 @@ def write_platform_outputs(
             "last_seen": entry.get("last_seen"),
             "runs": entry.get("runs", 0),
             "metadata_variants": len(entry.get("metadata_history", {})),
+            **platform_catalog.get((provider, device), {}),
         })
 
     index_payload = {"generated_at": generated_at, "platforms": index_platforms}

--- a/scripts/platform_catalog.json
+++ b/scripts/platform_catalog.json
@@ -1,0 +1,37 @@
+{
+  "platforms": [
+    {
+      "provider": "ibm",
+      "device": "ibm_brisbane",
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2025-11-03",
+        "source_url": "https://quantum.cloud.ibm.com/announcements/en/product-updates/2025-11-03-brisbane-retirement",
+        "source_label": "IBM retirement announcement"
+      }
+    },
+    {
+      "provider": "origin",
+      "device": "wukong_72",
+      "aliases": [
+        "72"
+      ],
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2026-04-09"
+      }
+    },
+    {
+      "provider": "origin",
+      "device": "wukong_102",
+      "aliases": [
+        "origin_wukong",
+        "WK_C102-2"
+      ],
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2026-04-09"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Introduces a curated platform catalog where we can manually add information about the devices, such as, their aliases, and the lifecycle. The immediate feature for this is to mark some devices as «retired». This will be reflected in a metriq-web style for device that are retires (metriq-web PR to follow)