### PR TITLE
mgym upload: BSEQ on catalystq/catalyst_q_v3_1

### DIFF
--- a/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-28-41_bseq_2d36cb49.json
+++ b/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-28-41_bseq_2d36cb49.json
@@ -1,0 +1,29 @@
+[
+  {
+    "app_version": "0.7.0",
+    "timestamp": "2026-06-11T17:28:41.560832",
+    "suite_id": null,
+    "job_type": "BSEQ",
+    "results": {
+      "largest_connected_size": 2000,
+      "fraction_connected": 1.0,
+      "score": {
+        "value": 2000.0,
+        "uncertainty": null
+      }
+    },
+    "platform": {
+      "device": "catalyst_q_v3_1",
+      "device_metadata": {
+        "num_qubits": 2000,
+        "simulator": true,
+        "version": "3.1.0-turbo"
+      },
+      "provider": "catalystq"
+    },
+    "params": {
+      "benchmark_name": "BSEQ",
+      "shots": 1000
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Metriq Gym benchmark data upload for `catalystq/catalyst_q_v3_1`.

This is a benchmark-score/data submission, not a unitaryHACK bounty PR or active hackathon workstream.

## Benchmark

- Suite: BSEQ
- Device metadata qubits: 2000
- `fraction_connected`: 1
- Score: 2000
- Shots: 1000