### PR TITLE
mgym upload: Mirror Circuits on catalystq/catalyst_q_v3_1

### DIFF
--- a/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-26-43_mirror_circuits_7f4c23db.json
+++ b/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-26-43_mirror_circuits_7f4c23db.json
@@ -1,0 +1,42 @@
+[
+  {
+    "app_version": "0.7.0",
+    "timestamp": "2026-06-11T17:26:43.943747",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 1.0,
+        "uncertainty": 0.0
+      },
+      "polarization": {
+        "value": 1.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": true,
+      "score": {
+        "value": 1.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "catalyst_q_v3_1",
+      "device_metadata": {
+        "num_qubits": 2000,
+        "simulator": true,
+        "version": "3.1.0-turbo"
+      },
+      "provider": "catalystq"
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 5,
+      "num_layers": 8,
+      "seed": 7,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.3,
+      "width": 16
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Metriq Gym benchmark data upload for `catalystq/catalyst_q_v3_1`.

This is a benchmark-score/data submission, not a unitaryHACK bounty PR or active hackathon workstream.

## Benchmark

- Suite: Mirror Circuits
- Device metadata qubits: 2000
- Binary success: true
- Success probability: 1 +/- 0
- Score: 1 +/- 0
- Shots: 1000