### PR TITLE
mgym upload: Bernstein-Vazirani on catalystq/catalyst_q_v3_1

### DIFF
--- a/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-24-35_bernstein-vazirani_865c0f07.json
+++ b/metriq-gym/v0.7/catalystq/catalyst_q_v3_1/2026-06-11_17-24-35_bernstein-vazirani_865c0f07.json
@@ -1,0 +1,36 @@
+[
+  {
+    "app_version": "0.7.0",
+    "timestamp": "2026-06-11T17:24:35.940803",
+    "suite_id": null,
+    "job_type": "Bernstein-Vazirani",
+    "results": {
+      "accuracy_score": {
+        "value": 1.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 1.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "catalyst_q_v3_1",
+      "device_metadata": {
+        "num_qubits": 2000,
+        "simulator": true,
+        "version": "3.1.0-turbo"
+      },
+      "provider": "catalystq"
+    },
+    "params": {
+      "benchmark_name": "Bernstein-Vazirani",
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 2
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Metriq Gym benchmark data upload for `catalystq/catalyst_q_v3_1`.

This is a benchmark-score/data submission, not a unitaryHACK bounty PR or active hackathon workstream.

## Benchmark

- Suite: Bernstein-Vazirani
- Device metadata qubits: 2000
- Accuracy score: 1 +/- 0
- Score: 1 +/- 0
- Shots: 1000