### PR TITLE
Fix path for Cepheus data

### DIFF
--- a/metriq-gym/v0.7/aws/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-15_16-26-08_wit_d3fa8744.json
+++ b/metriq-gym/v0.7/aws/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-15_16-26-08_wit_d3fa8744.json
@@ -15,7 +15,7 @@
       }
     },
     "platform": {
-      "device": "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q",
+      "device": "rigetti_cepheus-1-108q",
       "device_metadata": {
         "num_qubits": 107,
         "simulator": false

--- a/metriq-gym/v0.7/aws/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-15_16-26-08_wit_d3fa8744.json
+++ b/metriq-gym/v0.7/aws/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-15_16-26-08_wit_d3fa8744.json
@@ -1,6 +1,6 @@
 [
   {
-    "app_version": "2.dev8+g0ccc671f8",
+    "app_version": "0.7.0",
     "timestamp": "2026-07-15T16:26:08.016526",
     "suite_id": null,
     "job_type": "WIT",
@@ -20,7 +20,7 @@
         "num_qubits": 107,
         "simulator": false
       },
-      "provider": "braket"
+      "provider": "aws"
     },
     "circuit_metadata": {
       "input_two_qubit_gate_counts": [


### PR DESCRIPTION
Path was wrong because of the issue described here: https://github.com/unitaryfoundation/metriq-gym/pull/773

Manually fixing the provider field, because aliasing of that may only be supported in metriq-gym and not in the metriq-data pipelines yet.