### PR TITLE
Normalize AWS and Braket provider aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore generated outputs
 dist/
 
+# macOS metadata
+.DS_Store
+
 __pycache__/
 *.py[cod]
 *.pyo

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -6,7 +6,32 @@ from datetime import datetime, timezone
 from typing import Any
 
 
+AWS_PROVIDER = "aws"
+AWS_PROVIDER_ALIASES = frozenset({AWS_PROVIDER, "braket"})
+
+
 # ---------------------------- Utilities ----------------------------
+
+
+def canonical_provider_name(provider: str) -> str:
+    """Return the canonical provider identifier while accepting known aliases."""
+    stripped = provider.strip()
+    if stripped.lower() in AWS_PROVIDER_ALIASES:
+        return AWS_PROVIDER
+    return stripped
+
+
+def canonical_device_name(provider: str, device: str) -> str:
+    """Normalize provider-specific device identifiers used as dataset keys."""
+    stripped = device.strip()
+    if canonical_provider_name(provider) != AWS_PROVIDER:
+        return stripped
+
+    parts = [part for part in stripped.split("/") if part]
+    if len(parts) >= 2:
+        stripped = f"{parts[-2]}_{parts[-1]}"
+    return stripped.lower()
+
 
 def iso_utc_now() -> str:
     dt = datetime.now(timezone.utc)
@@ -143,6 +168,14 @@ def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
     if device_metadata is not None:
         out["device_metadata"] = device_metadata
 
+    provider = out.get("provider")
+    device = out.get("device")
+    if isinstance(provider, str):
+        provider = canonical_provider_name(provider)
+        out["provider"] = provider
+        if isinstance(device, str):
+            out["device"] = canonical_device_name(provider, device)
+
     r = out.get("results") if "results" in out else row.get("results")
     if isinstance(r, dict):
         # Newer schema variant (sometimes mixed with scalar flags like `binary_success`):
@@ -189,7 +222,10 @@ def get_provider_device(row: dict[str, Any]) -> tuple[str | None, str | None]:
         if isinstance(platform, dict):
             provider = provider or platform.get("provider")
             device = device or platform.get("device")
-    return provider, device
+    if not isinstance(provider, str) or not isinstance(device, str):
+        return None, None
+    canonical_provider = canonical_provider_name(provider)
+    return canonical_provider, canonical_device_name(canonical_provider, device)
 
 
 def _normalize_platform_lifecycle(lifecycle: Any) -> dict[str, str] | None:
@@ -245,6 +281,8 @@ def load_platform_catalog(root: str) -> dict[tuple[str, str], dict[str, Any]]:
         if not isinstance(device, str) or not device.strip():
             continue
 
+        provider = canonical_provider_name(provider)
+        device = canonical_device_name(provider, device)
         lifecycle = _normalize_platform_lifecycle(entry.get("lifecycle"))
 
         names = [device.strip()]
@@ -252,13 +290,13 @@ def load_platform_catalog(root: str) -> dict[tuple[str, str], dict[str, Any]]:
         if isinstance(aliases, list):
             for alias in aliases:
                 if isinstance(alias, str) and alias.strip():
-                    names.append(alias.strip())
+                    names.append(canonical_device_name(provider, alias))
 
         payload: dict[str, Any] = {}
         if lifecycle is not None:
             payload["lifecycle"] = lifecycle
         for name in dict.fromkeys(names):
-            key = (provider.strip(), name)
+            key = (provider, name)
             existing = resolved.get(key)
             if existing is not None and existing != payload:
                 print(
@@ -377,7 +415,11 @@ def write_platform_outputs(
             dev = rec.get("device")
             if not prov or not dev:
                 continue
-            key: PlatformKey = (str(prov), str(dev))
+            canonical_provider = canonical_provider_name(str(prov))
+            key: PlatformKey = (
+                canonical_provider,
+                canonical_device_name(canonical_provider, str(dev)),
+            )
             composite_map[key] = rec
 
     for (provider, device) in sorted(registry.keys(), key=lambda k: (k[0], k[1])):

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -4,7 +4,14 @@ import os
 import sys
 from typing import Any
 
-from etl import canonical_json, derive_benchmark_name, parse_timestamp
+from etl import (
+    canonical_device_name,
+    canonical_json,
+    canonical_provider_name,
+    derive_benchmark_name,
+    parse_timestamp,
+)
+
 
 def _coerce_float(val: Any) -> float | None:
     try:
@@ -253,7 +260,10 @@ def _baseline_provider_device_for_series(
         return None, None
     provider = baseline.get("provider") if isinstance(baseline.get("provider"), str) else None
     device = baseline.get("device") if isinstance(baseline.get("device"), str) else None
-    return provider, device
+    if provider is None or device is None:
+        return provider, device
+    provider = canonical_provider_name(provider)
+    return provider, canonical_device_name(provider, device)
 
 
 def _is_baseline_row_for_series(

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -1,0 +1,94 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from etl import (  # noqa: E402
+    canonical_device_name,
+    canonical_provider_name,
+    flatten_row,
+    load_platform_catalog,
+    upsert_platform,
+    write_platform_outputs,
+)
+from score import _baseline_provider_device_for_series  # noqa: E402
+
+
+CEPHEUS_ARN = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
+
+
+class ProviderAliasTests(unittest.TestCase):
+    def test_aws_and_braket_share_canonical_platform_identity(self):
+        for alias in ("aws", "AWS", "braket", "Braket"):
+            with self.subTest(alias=alias):
+                self.assertEqual(canonical_provider_name(alias), "aws")
+                self.assertEqual(
+                    canonical_device_name(alias, CEPHEUS_ARN),
+                    "rigetti_cepheus-1-108q",
+                )
+
+    def test_flatten_and_registry_canonicalize_legacy_braket_record(self):
+        row = {
+            "timestamp": "2026-07-15T16:26:08",
+            "platform": {
+                "provider": "braket",
+                "device": CEPHEUS_ARN,
+                "device_metadata": {"num_qubits": 107},
+            },
+            "results": {"score": {"value": 0.5}},
+        }
+
+        flat = flatten_row(row)
+        self.assertEqual(flat["provider"], "aws")
+        self.assertEqual(flat["device"], "rigetti_cepheus-1-108q")
+
+        registry = {}
+        upsert_platform(registry, row, "result.json", "v0.7")
+        self.assertIn(("aws", "rigetti_cepheus-1-108q"), registry)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            count, _ = write_platform_outputs(registry, tmp, "2026-07-16T00:00:00Z")
+            self.assertEqual(count, 1)
+            self.assertTrue(
+                (Path(tmp) / "platforms" / "aws" / "rigetti_cepheus-1-108q.json").is_file()
+            )
+
+    def test_catalog_and_scoring_config_accept_braket_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            scripts_dir = Path(tmp) / "scripts"
+            scripts_dir.mkdir()
+            (scripts_dir / "platform_catalog.json").write_text(
+                json.dumps(
+                    {
+                        "platforms": [
+                            {
+                                "provider": "braket",
+                                "device": CEPHEUS_ARN,
+                                "lifecycle": {"status": "active"},
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            catalog = load_platform_catalog(tmp)
+
+        self.assertEqual(
+            catalog[("aws", "rigetti_cepheus-1-108q")],
+            {"lifecycle": {"status": "active"}},
+        )
+
+        config = {"default": {"baseline": {"provider": "braket", "device": CEPHEUS_ARN}}}
+        self.assertEqual(
+            _baseline_provider_device_for_series(config, "v0.7"),
+            ("aws", "rigetti_cepheus-1-108q"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- treat `braket` as an alias of the canonical `aws` provider during aggregation
- normalize AWS Braket device ARNs to stable device keys across benchmark rows, platform registries, catalogs, scoring baselines, and composite score lookup
- add regression coverage for the legacy Cepheus `braket` + full-ARN record
- ignore macOS `.DS_Store` metadata

## Validation

- `python -m unittest discover -s tests -v` — 3 passed
- full aggregation of 255 rows from 225 files
- verified a legacy `braket` Cepheus record generates `aws/rigetti_cepheus-1-108q` benchmark and platform outputs
- `git diff --check`