### PR TITLE
Emit required_num_qubits per composite component

### DIFF
--- a/scripts/score.py
+++ b/scripts/score.py
@@ -902,6 +902,13 @@ def compute_device_composite_scores(
                 "raw_timestamp": raw_ts,
             }
 
+            # Surface a structural qubit requirement when the component selects a
+            # fixed qubit count. This lets the UI tell a benchmark a device cannot
+            # run (device qubits below the requirement) apart from one that is
+            # simply missing a submission.
+            if isinstance(selector, dict) and isinstance(selector.get("num_qubits"), int):
+                breakdown[label]["required_num_qubits"] = selector["num_qubits"]
+
         # Denominator is the sum of all defined weights; missing components
         # contribute 0 to the numerator but still count in the denominator.
         if sum_w_defined > 0.0:


### PR DESCRIPTION
Supports unitaryfoundation/metriq-web#22 (distinguishing unsupported benchmarks from missing submissions in Coverage).

## What

Each composite component whose scoring selector fixes a qubit count (`selector: {num_qubits: N}`) now carries `required_num_qubits: N` in the platform score breakdown. Components without such a selector are unchanged.

## Why

Today the Coverage display can't tell two situations apart, because the data doesn't distinguish them: a benchmark the device structurally cannot run (for example a 50-qubit component on a 20-qubit device) looks the same as a benchmark that is runnable but has no submission yet. Surfacing the requirement lets metriq-web compare it against the device's qubit count and classify the two states.

## Validation

Ran `scripts/aggregate.py` over the repo's result data: all 17 platform outputs now include `required_num_qubits` for the QMLK, WIT, and Linear Ramp QAOA components (10/20/30/50/100 as configured in scoring.json). Example, `aws/iqm_garnet` (20 qubits): QMLK-30/50 and LR-QAOA-50/100 carry requirements above 20, so the frontend can mark them unsupported rather than missing.

The metriq-web change that consumes this field is in a companion PR.