### PR TITLE
Retire ibm_torino and use ibm_boston as baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Example `scripts/scoring.json`:
     }
   },
   "default": {
-    "baseline": { "provider": "ibm", "device": "ibm_torino" },
+    "baseline": { "provider": "ibm", "device": "ibm_boston" },
     "composite": {
       "components": [
         {
@@ -139,6 +139,19 @@ Example `scripts/scoring.json`:
 
 Baselines are computed per major series (e.g., all `v0.x.y` share one baseline reference),
 using the latest available baseline row per `(benchmark, metric, selector)` key.
+The canonical baseline for the latest observed series is also published in
+`dist/platforms/index.json` so downstream clients can identify it without duplicating
+the scoring configuration:
+
+```json
+{
+  "baseline": {
+    "provider": "ibm",
+    "device": "ibm_boston",
+    "series": "v0.7"
+  }
+}
+```
 
 ### Curated platform catalog
 

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -30,6 +30,7 @@ from score import (
     compute_baseline_averages_by_series,
     compute_and_attach_metriq_scores,
     compute_device_composite_scores,
+    baseline_metadata_for_latest_series,
 )
 
 
@@ -70,6 +71,7 @@ def main(argv: list[str] | None = None) -> int:
     # Also write per-series outputs mirroring source dataset structure
     #  - dist/<series>/benchmark.latest.json
     series_labels = sorted(set(row_series.values()))
+    baseline_metadata = baseline_metadata_for_latest_series(scoring_cfg, series_labels)
     for s in series_labels:
         s_dir = os.path.join(dist_path, s)
         ensure_dir(s_dir)
@@ -88,6 +90,7 @@ def main(argv: list[str] | None = None) -> int:
         generated_at,
         composite_records,
         platform_catalog,
+        baseline=baseline_metadata,
     )
 
     print(

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -469,9 +469,10 @@ def write_platform_outputs(
 
     index_payload = {
         "generated_at": generated_at,
-        "baseline": baseline,
         "platforms": index_platforms,
     }
+    if baseline is not None:
+        index_payload["baseline"] = baseline
     index_file = os.path.join(platforms_dir, "index.json")
     with open(index_file, "w", encoding="utf-8") as f:
         f.write(json.dumps(index_payload, ensure_ascii=False, indent=2))

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -399,6 +399,7 @@ def write_platform_outputs(
     generated_at: str,
     composite_records: list[dict[str, Any]] | None = None,
     platform_catalog: dict[PlatformKey, dict[str, Any]] | None = None,
+    baseline: dict[str, str] | None = None,
 ) -> tuple[int, str]:
     platforms_dir = os.path.join(dist_path, "platforms")
     ensure_dir(platforms_dir)
@@ -466,7 +467,11 @@ def write_platform_outputs(
             **platform_catalog.get((provider, device), {}),
         })
 
-    index_payload = {"generated_at": generated_at, "platforms": index_platforms}
+    index_payload = {
+        "generated_at": generated_at,
+        "baseline": baseline,
+        "platforms": index_platforms,
+    }
     index_file = os.path.join(platforms_dir, "index.json")
     with open(index_file, "w", encoding="utf-8") as f:
         f.write(json.dumps(index_payload, ensure_ascii=False, indent=2))

--- a/scripts/platform_catalog.json
+++ b/scripts/platform_catalog.json
@@ -11,6 +11,16 @@
       }
     },
     {
+      "provider": "ibm",
+      "device": "ibm_torino",
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2026-04-01",
+        "source_url": "https://quantum.cloud.ibm.com/announcements/product-updates/2026-04-01-torino-retirement",
+        "source_label": "IBM retirement announcement"
+      }
+    },
+    {
       "provider": "origin",
       "device": "wukong_72",
       "aliases": [

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -266,6 +266,33 @@ def _baseline_provider_device_for_series(
     return provider, canonical_device_name(provider, device)
 
 
+def baseline_metadata_for_latest_series(
+    scoring_cfg: dict[str, Any],
+    series_labels: list[str],
+) -> dict[str, str] | None:
+    """Return the canonical baseline configured for the latest observed series."""
+    latest_series: str | None = None
+    latest_version: tuple[int, ...] | None = None
+    for series in series_labels:
+        version = _parse_series_label(series)
+        if version is None:
+            continue
+        if latest_version is None or version > latest_version:
+            latest_series = series
+            latest_version = version
+
+    if latest_series is None:
+        return None
+    provider, device = _baseline_provider_device_for_series(scoring_cfg, latest_series)
+    if provider is None or device is None:
+        return None
+    return {
+        "provider": provider,
+        "device": device,
+        "series": latest_series,
+    }
+
+
 def _is_baseline_row_for_series(
     scoring_cfg: dict[str, Any],
     series_label: str | None,

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -3,7 +3,7 @@
     "v0.4": {
       "baseline": {
         "provider": "ibm",
-        "device": "ibm_torino"
+        "device": "ibm_boston"
       },
       "composite": {
         "components": [
@@ -213,7 +213,7 @@
   "default": {
     "baseline": {
       "provider": "ibm",
-      "device": "ibm_torino"
+      "device": "ibm_boston"
     },
     "composite": {
       "components": [

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -16,7 +16,10 @@ from etl import (  # noqa: E402
     upsert_platform,
     write_platform_outputs,
 )
-from score import _baseline_provider_device_for_series  # noqa: E402
+from score import (  # noqa: E402
+    _baseline_provider_device_for_series,
+    baseline_metadata_for_latest_series,
+)
 
 
 CEPHEUS_ARN = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
@@ -88,6 +91,37 @@ class ProviderAliasTests(unittest.TestCase):
             _baseline_provider_device_for_series(config, "v0.7"),
             ("aws", "rigetti_cepheus-1-108q"),
         )
+        self.assertEqual(
+            baseline_metadata_for_latest_series(config, ["v0.9", "v0.10", "unknown"]),
+            {
+                "provider": "aws",
+                "device": "rigetti_cepheus-1-108q",
+                "series": "v0.10",
+            },
+        )
+
+    def test_platform_index_publishes_baseline_metadata(self):
+        row = {
+            "timestamp": "2026-07-15T16:26:08",
+            "platform": {"provider": "ibm", "device": "ibm_boston"},
+            "results": {"score": {"value": 0.5}},
+        }
+        registry = {}
+        upsert_platform(registry, row, "result.json", "v0.7")
+        baseline = {"provider": "ibm", "device": "ibm_boston", "series": "v0.7"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            write_platform_outputs(
+                registry,
+                tmp,
+                "2026-07-16T00:00:00Z",
+                baseline=baseline,
+            )
+            index = json.loads(
+                (Path(tmp) / "platforms" / "index.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(index["baseline"], baseline)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- mark `ibm_torino` retired as of 1 April 2026, citing IBM's retirement announcement
- use `ibm_boston`, the latest Heron r3 platform represented in the dataset, as the `v0` scoring baseline
- publish the latest observed series and its canonical baseline in `dist/platforms/index.json` so downstream clients can use `metriq-data` as the source of truth
- document and test the published baseline metadata

Because Metriq is still pre-1.0, aggregation recalculates existing `v0` scores against Boston. Raw Torino measurements remain available unchanged as historical data.

## Validation

- `python3.13 scripts/aggregate.py` — processed 257 rows and 18 platforms; published `ibm/ibm_boston` for series `v0.7`
- `python -m pytest -q` — 4 tests and 4 subtests passed

Closes #468
