### PR TITLE
mgym upload: QMLK-10 on IQM/Garnet

### DIFF
--- a/metriq-gym/v0.7/aws/arn_aws_braket_eu-north-1_device_qpu_iqm_garnet/2026-07-23_12-56-54_qml_kernel_292c9f5f.json
+++ b/metriq-gym/v0.7/aws/arn_aws_braket_eu-north-1_device_qpu_iqm_garnet/2026-07-23_12-56-54_qml_kernel_292c9f5f.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.7.2.dev1+g22e9742d3.d20260723",
+    "timestamp": "2026-07-23T12:56:54.120630",
+    "suite_id": null,
+    "job_type": "QML Kernel",
+    "results": {
+      "accuracy_score": {
+        "value": 0.205,
+        "uncertainty": 0.0127661662216971
+      },
+      "score": {
+        "value": 0.205,
+        "uncertainty": 0.0127661662216971
+      }
+    },
+    "platform": {
+      "device": "iqm_garnet",
+      "device_metadata": {
+        "num_qubits": 20,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        36
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        36
+      ]
+    },
+    "params": {
+      "benchmark_name": "QML Kernel",
+      "num_qubits": 10,
+      "shots": 1000
+    }
+  }
+]


### PR DESCRIPTION
Run via metriq-gym without verbatim mode since braket supports barrier now.