### PR TITLE
Split QFT into per-qubit-count scoring components

### DIFF
--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -334,8 +334,38 @@
             {
               "benchmark": "Quantum Fourier Transform",
               "metric": "score",
-              "label": "Quantum Fourier Transform:score",
-              "weight": "1/1"
+              "selector": {
+                "num_qubits": 10
+              },
+              "label": "QFT-10:score",
+              "weight": "1/4"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": {
+                "num_qubits": 20
+              },
+              "label": "QFT-20:score",
+              "weight": "1/4"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": {
+                "num_qubits": 30
+              },
+              "label": "QFT-30:score",
+              "weight": "1/4"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": {
+                "num_qubits": 50
+              },
+              "label": "QFT-50:score",
+              "weight": "1/4"
             }
           ]
         },


### PR DESCRIPTION
Companion to metriq-gym#780. Ready for review, but not ready to merge until new-format QFT data exists (see below).

## What

Splits the single `Quantum Fourier Transform` component in the `default` composite into a group of `num_qubits`-selector components for {10, 20, 30, 50}, the same pattern QML Kernel uses (QMLK-10, QMLK-20, ...). Qubit counts follow the paper sweep (arXiv:2603.08680, section IV.B.4); subweights are uniform 1/4, matching QMLK on `main`. The `v0.4` series block is untouched, so historical data keeps the old single-component scheme.

## Why it cannot merge yet

metriq-gym#780 has merged, so new QFT dispatches now record a single `num_qubits`. But no QFT results in this repo use that format yet. All five still carry the old range parameters:

```
params: {min_qubits: 4, max_qubits: 12, skip_qubits: 4, ...}   # no num_qubits
```

`_row_param_matches({num_qubits: 10}, record)` reads `record.params.num_qubits`, which none of these have, so the new components match nothing. Running `aggregate.py` on current data with this config, no device ends up with a populated QFT component, which drops QFT out of the composite for the devices that have QFT results today (origin/wukong_72, quantinuum/H2-2 among them). That is a regression, not a no-op.

The other direction works: a record with `params.num_qubits: 10` populates `QFT-10:score` and leaves the other three empty.

## Order

1. Run a QFT sweep with the `qft_sweep` suite from metriq-gym#780 and upload the results.
2. Merge this.

Reviewing the shape now is useful regardless, in particular the choice of {10, 20, 30, 50} and the uniform 1/4 subweights. If #472's size-proportional subweight scheme lands first, these should follow it.
