### PR TITLE
Mark Rigetti Ankaa-3 as retired

### DIFF
--- a/scripts/platform_catalog.json
+++ b/scripts/platform_catalog.json
@@ -11,6 +11,16 @@
       }
     },
     {
+      "provider": "aws",
+      "device": "rigetti_ankaa-3",
+      "lifecycle": {
+        "status": "retired",
+        "effective_at": "2026-04-17",
+        "source_url": "https://rigetti.statuspage.io/incidents/dbsh9sb7wt1k",
+        "source_label": "Rigetti retirement announcement"
+      }
+    },
+    {
       "provider": "origin",
       "device": "wukong_72",
       "aliases": [

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -94,16 +94,16 @@ class ProviderAliasTests(unittest.TestCase):
 class PlatformCatalogTests(unittest.TestCase):
     def test_ankaa_3_is_retired(self):
         catalog = load_platform_catalog(str(REPO_ROOT))
+        platform_key = ("aws", "rigetti_ankaa-3")
 
+        self.assertIn(platform_key, catalog)
         self.assertEqual(
-            catalog[("aws", "rigetti_ankaa-3")],
+            catalog[platform_key]["lifecycle"],
             {
-                "lifecycle": {
-                    "status": "retired",
-                    "effective_at": "2026-04-17",
-                    "source_url": "https://rigetti.statuspage.io/incidents/dbsh9sb7wt1k",
-                    "source_label": "Rigetti retirement announcement",
-                }
+                "status": "retired",
+                "effective_at": "2026-04-17",
+                "source_url": "https://rigetti.statuspage.io/incidents/dbsh9sb7wt1k",
+                "source_label": "Rigetti retirement announcement",
             },
         )
 

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+REPO_ROOT = SCRIPTS_DIR.parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from etl import (  # noqa: E402
@@ -87,6 +88,23 @@ class ProviderAliasTests(unittest.TestCase):
         self.assertEqual(
             _baseline_provider_device_for_series(config, "v0.7"),
             ("aws", "rigetti_cepheus-1-108q"),
+        )
+
+
+class PlatformCatalogTests(unittest.TestCase):
+    def test_ankaa_3_is_retired(self):
+        catalog = load_platform_catalog(str(REPO_ROOT))
+
+        self.assertEqual(
+            catalog[("aws", "rigetti_ankaa-3")],
+            {
+                "lifecycle": {
+                    "status": "retired",
+                    "effective_at": "2026-04-17",
+                    "source_url": "https://rigetti.statuspage.io/incidents/dbsh9sb7wt1k",
+                    "source_label": "Rigetti retirement announcement",
+                }
+            },
         )
 
 


### PR DESCRIPTION
## Summary

- Mark `aws / rigetti_ankaa-3` as retired effective April 17, 2026.
- Store Rigetti's official retirement announcement as lifecycle provenance.
- Add regression coverage for the curated catalog entry.

## Why

Rigetti officially retired Ankaa-3 and directs users to Cepheus-1-108Q. Keeping this status in the curated platform catalog preserves `metriq-data` as the operational source of truth; downstream consumers such as `metriq-web` receive the lifecycle state through generated platform JSON.

## Impact

The next platform aggregation will include Ankaa-3's retired lifecycle metadata in the generated platform index and detail payload.

## Checks

- `uv run python -m unittest tests.test_provider_aliases`
