### PR TITLE
Publish canonical baseline in platforms index

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ Example `scripts/scoring.json`:
 
 Baselines are computed per major series (e.g., all `v0.x.y` share one baseline reference),
 using the latest available baseline row per `(benchmark, metric, selector)` key.
+The canonical baseline for the latest observed series is also published in
+`dist/platforms/index.json` so downstream clients can identify it without duplicating
+the scoring configuration:
+
+```json
+{
+  "baseline": {
+    "provider": "ibm",
+    "device": "ibm_torino",
+    "series": "v0.7"
+  }
+}
+```
 
 ### Curated platform catalog
 

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -30,6 +30,7 @@ from score import (
     compute_baseline_averages_by_series,
     compute_and_attach_metriq_scores,
     compute_device_composite_scores,
+    baseline_metadata_for_latest_series,
 )
 
 
@@ -70,6 +71,7 @@ def main(argv: list[str] | None = None) -> int:
     # Also write per-series outputs mirroring source dataset structure
     #  - dist/<series>/benchmark.latest.json
     series_labels = sorted(set(row_series.values()))
+    baseline_metadata = baseline_metadata_for_latest_series(scoring_cfg, series_labels)
     for s in series_labels:
         s_dir = os.path.join(dist_path, s)
         ensure_dir(s_dir)
@@ -88,6 +90,7 @@ def main(argv: list[str] | None = None) -> int:
         generated_at,
         composite_records,
         platform_catalog,
+        baseline=baseline_metadata,
     )
 
     print(

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -399,6 +399,7 @@ def write_platform_outputs(
     generated_at: str,
     composite_records: list[dict[str, Any]] | None = None,
     platform_catalog: dict[PlatformKey, dict[str, Any]] | None = None,
+    baseline: dict[str, str] | None = None,
 ) -> tuple[int, str]:
     platforms_dir = os.path.join(dist_path, "platforms")
     ensure_dir(platforms_dir)
@@ -466,7 +467,12 @@ def write_platform_outputs(
             **platform_catalog.get((provider, device), {}),
         })
 
-    index_payload = {"generated_at": generated_at, "platforms": index_platforms}
+    index_payload = {
+        "generated_at": generated_at,
+        "platforms": index_platforms,
+    }
+    if baseline is not None:
+        index_payload["baseline"] = baseline
     index_file = os.path.join(platforms_dir, "index.json")
     with open(index_file, "w", encoding="utf-8") as f:
         f.write(json.dumps(index_payload, ensure_ascii=False, indent=2))

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -266,6 +266,33 @@ def _baseline_provider_device_for_series(
     return provider, canonical_device_name(provider, device)
 
 
+def baseline_metadata_for_latest_series(
+    scoring_cfg: dict[str, Any],
+    series_labels: list[str],
+) -> dict[str, str] | None:
+    """Return the canonical baseline configured for the latest observed series."""
+    latest_series: str | None = None
+    latest_version: tuple[int, ...] | None = None
+    for series in series_labels:
+        version = _parse_series_label(series)
+        if version is None:
+            continue
+        if latest_version is None or version > latest_version:
+            latest_series = series
+            latest_version = version
+
+    if latest_series is None:
+        return None
+    provider, device = _baseline_provider_device_for_series(scoring_cfg, latest_series)
+    if provider is None or device is None:
+        return None
+    return {
+        "provider": provider,
+        "device": device,
+        "series": latest_series,
+    }
+
+
 def _is_baseline_row_for_series(
     scoring_cfg: dict[str, Any],
     series_label: str | None,

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -17,7 +17,10 @@ from etl import (  # noqa: E402
     upsert_platform,
     write_platform_outputs,
 )
-from score import _baseline_provider_device_for_series  # noqa: E402
+from score import (  # noqa: E402
+    _baseline_provider_device_for_series,
+    baseline_metadata_for_latest_series,
+)
 
 
 CEPHEUS_ARN = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
@@ -58,6 +61,10 @@ class ProviderAliasTests(unittest.TestCase):
             self.assertTrue(
                 (Path(tmp) / "platforms" / "aws" / "rigetti_cepheus-1-108q.json").is_file()
             )
+            index = json.loads(
+                (Path(tmp) / "platforms" / "index.json").read_text(encoding="utf-8")
+            )
+            self.assertNotIn("baseline", index)
 
     def test_catalog_and_scoring_config_accept_braket_alias(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -89,6 +96,37 @@ class ProviderAliasTests(unittest.TestCase):
             _baseline_provider_device_for_series(config, "v0.7"),
             ("aws", "rigetti_cepheus-1-108q"),
         )
+        self.assertEqual(
+            baseline_metadata_for_latest_series(config, ["v0.9", "v0.10", "unknown"]),
+            {
+                "provider": "aws",
+                "device": "rigetti_cepheus-1-108q",
+                "series": "v0.10",
+            },
+        )
+
+    def test_platform_index_publishes_baseline_metadata(self):
+        row = {
+            "timestamp": "2026-07-15T16:26:08",
+            "platform": {"provider": "ibm", "device": "ibm_torino"},
+            "results": {"score": {"value": 0.5}},
+        }
+        registry = {}
+        upsert_platform(registry, row, "result.json", "v0.7")
+        baseline = {"provider": "ibm", "device": "ibm_torino", "series": "v0.7"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            write_platform_outputs(
+                registry,
+                tmp,
+                "2026-07-16T00:00:00Z",
+                baseline=baseline,
+            )
+            index = json.loads(
+                (Path(tmp) / "platforms" / "index.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(index["baseline"], baseline)
 
 
 class PlatformCatalogTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Publish the canonical baseline for the latest observed series in `dist/platforms/index.json`.
- Derive the metadata directly from `scripts/scoring.json`, including provider/device canonicalization.
- Omit the `baseline` field when no valid baseline can be determined.
- Document and test the published payload.

## Scope

This extracts only the baseline-publication mechanism from #475. It deliberately does **not** retire `ibm_torino`, modify `scripts/platform_catalog.json`, or switch the scoring baseline to `ibm_boston`. The current generated metadata remains:

```json
{
  "provider": "ibm",
  "device": "ibm_torino",
  "series": "v0.7"
}
```

Publishing this metadata lets unitaryfoundation/metriq-web#27 consume `metriq-data` as the source of truth without coupling that mechanism to a baseline change.

## Validation

- `python -m unittest discover -s tests -v` — 5 tests passed
- `python scripts/aggregate.py` — processed 281 rows across 20 platforms; published `ibm/ibm_torino` for `v0.7`
- `git diff --check`
