### PR TITLE
mgym upload: Mirror Circuits (w=16, d=32) on Rigetti Cepheus-1-108Q

### DIFF
--- a/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_11-04-21_mirror_circuits_951d96e9.json
+++ b/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_11-04-21_mirror_circuits_951d96e9.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-04T11:04:21.405713",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "rigetti_cepheus-1-108q",
+      "device_metadata": {
+        "num_qubits": 107,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        236,
+        210,
+        242,
+        228,
+        198,
+        204,
+        198,
+        212,
+        230,
+        204
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        236,
+        210,
+        242,
+        228,
+        198,
+        204,
+        198,
+        212,
+        230,
+        204
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 32,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 16
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=16, d=32) on Rigetti Cepheus-1-108Q via the standard metriq-gym workflow (no verbatim mode): polarization 0.0, success probability 0.0.
