### PR TITLE
mgym upload: Mirror Circuits (w=24, d=16) on Rigetti Cepheus-1-108Q

### DIFF
--- a/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_11-05-14_mirror_circuits_92a0ba4f.json
+++ b/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_11-05-14_mirror_circuits_92a0ba4f.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-04T11:05:14.553762",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "rigetti_cepheus-1-108q",
+      "device_metadata": {
+        "num_qubits": 107,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        164,
+        166,
+        162,
+        142,
+        158,
+        174,
+        182,
+        156,
+        170,
+        188
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        164,
+        166,
+        162,
+        142,
+        158,
+        174,
+        182,
+        156,
+        170,
+        188
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 16,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 24
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=24, d=16) on Rigetti Cepheus-1-108Q via the standard metriq-gym workflow (no verbatim mode): polarization 0.0, success probability 0.0.
