### PR TITLE
mgym upload: Mirror Circuits (w=64, d=4) on Rigetti Cepheus-1-108Q

### DIFF
--- a/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_12-41-47_mirror_circuits_5727b2f3.json
+++ b/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-04_12-41-47_mirror_circuits_5727b2f3.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-04T12:41:47.027639",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "rigetti_cepheus-1-108q",
+      "device_metadata": {
+        "num_qubits": 107,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        118,
+        118,
+        108,
+        110,
+        114,
+        124,
+        126,
+        108,
+        100,
+        102
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        118,
+        118,
+        108,
+        110,
+        114,
+        124,
+        126,
+        108,
+        100,
+        102
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 4,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 64
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=64, d=4) on Rigetti Cepheus-1-108Q via the standard metriq-gym workflow (no verbatim mode): polarization 0.0, success probability 0.0.
