### PR TITLE
Consolidate QFT benchmark uploads for the Metriq paper

### DIFF
--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-04_quantum_fourier_transform_6d15a0a2.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-04_quantum_fourier_transform_6d15a0a2.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:04.411221",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.9780000000000001,
+        "uncertainty": 0.002
+      },
+      "score": {
+        "value": 0.9780000000000001,
+        "uncertainty": 0.002
+      }
+    },
+    "runtime_seconds": 3.16728,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-15_quantum_fourier_transform_dba4d113.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-15_quantum_fourier_transform_dba4d113.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:15.223961",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.862,
+        "uncertainty": 0.006
+      },
+      "score": {
+        "value": 0.862,
+        "uncertainty": 0.006
+      }
+    },
+    "runtime_seconds": 1.682242,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-24_quantum_fourier_transform_8ac7bf8a.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-24_quantum_fourier_transform_8ac7bf8a.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:24.993649",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.73,
+        "uncertainty": 0.008
+      },
+      "score": {
+        "value": 0.73,
+        "uncertainty": 0.008
+      }
+    },
+    "runtime_seconds": 1.719018,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-35_quantum_fourier_transform_c129e787.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-35_quantum_fourier_transform_c129e787.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:35.280780",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.42,
+        "uncertainty": 0.014
+      },
+      "score": {
+        "value": 0.42,
+        "uncertainty": 0.014
+      }
+    },
+    "runtime_seconds": 1.774428,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-46_quantum_fourier_transform_1d688e65.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-46_quantum_fourier_transform_1d688e65.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:46.289680",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.157,
+        "uncertainty": 0.034
+      },
+      "score": {
+        "value": 0.157,
+        "uncertainty": 0.034
+      }
+    },
+    "runtime_seconds": 1.781728,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-56_quantum_fourier_transform_257a1e71.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-27-56_quantum_fourier_transform_257a1e71.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:27:56.226082",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.038,
+        "uncertainty": 0.006
+      },
+      "score": {
+        "value": 0.038,
+        "uncertainty": 0.006
+      }
+    },
+    "runtime_seconds": 1.850375,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-06_quantum_fourier_transform_29dbdac5.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-06_quantum_fourier_transform_29dbdac5.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:06.403989",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.008,
+        "uncertainty": 0.002
+      },
+      "score": {
+        "value": 0.008,
+        "uncertainty": 0.002
+      }
+    },
+    "runtime_seconds": 2.889653,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-16_quantum_fourier_transform_9459f944.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-16_quantum_fourier_transform_9459f944.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:16.601758",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.051946,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-26_quantum_fourier_transform_bbe89fd8.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-26_quantum_fourier_transform_bbe89fd8.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:26.433758",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.112817,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-36_quantum_fourier_transform_cbae26bf.json
+++ b/metriq-gym/v0.6/ibm/ibm_boston/2026-02-09_14-28-36_quantum_fourier_transform_cbae26bf.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:36.982328",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.227072,
+    "platform": {
+      "device": "ibm_boston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.4"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-15_quantum_fourier_transform_c332fb55.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-15_quantum_fourier_transform_c332fb55.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:15.354426",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.9499999999999998,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.9499999999999998,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.755204,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-26_quantum_fourier_transform_acab2187.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-26_quantum_fourier_transform_acab2187.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:26.462289",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.674,
+        "uncertainty": 0.047
+      },
+      "score": {
+        "value": 0.674,
+        "uncertainty": 0.047
+      }
+    },
+    "runtime_seconds": 1.77487,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-36_quantum_fourier_transform_eea2aa6e.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-36_quantum_fourier_transform_eea2aa6e.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:36.805057",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.377,
+        "uncertainty": 0.016
+      },
+      "score": {
+        "value": 0.377,
+        "uncertainty": 0.016
+      }
+    },
+    "runtime_seconds": 1.790591,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-47_quantum_fourier_transform_d985ff08.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-47_quantum_fourier_transform_d985ff08.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:47.761867",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.024000000000000004,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.024000000000000004,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.816577,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-58_quantum_fourier_transform_04ce9841.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-32-58_quantum_fourier_transform_04ce9841.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:58.313464",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.011000000000000001,
+        "uncertainty": 0.005
+      },
+      "score": {
+        "value": 0.011000000000000001,
+        "uncertainty": 0.005
+      }
+    },
+    "runtime_seconds": 1.866498,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-09_quantum_fourier_transform_0d4af69c.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-09_quantum_fourier_transform_0d4af69c.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:33:09.784106",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.001,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.001,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 1.92895,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-20_quantum_fourier_transform_18e23ce6.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-20_quantum_fourier_transform_18e23ce6.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:33:20.940183",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.003918,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-32_quantum_fourier_transform_fee4e780.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-32_quantum_fourier_transform_fee4e780.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:33:32.613458",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.107296,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-43_quantum_fourier_transform_de33db6d.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-43_quantum_fourier_transform_de33db6d.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:33:43.675895",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.185613,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-54_quantum_fourier_transform_0922da88.json
+++ b/metriq-gym/v0.6/ibm/ibm_fez/2026-02-09_14-33-54_quantum_fourier_transform_0922da88.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:33:54.743362",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.32149,
+    "platform": {
+      "device": "ibm_fez",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.3.34"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-28-47_quantum_fourier_transform_6e1cb467.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-28-47_quantum_fourier_transform_6e1cb467.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:47.220075",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.965,
+        "uncertainty": 0.004
+      },
+      "score": {
+        "value": 0.965,
+        "uncertainty": 0.004
+      }
+    },
+    "runtime_seconds": 1.708839,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-28-57_quantum_fourier_transform_c4318218.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-28-57_quantum_fourier_transform_c4318218.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:28:57.569203",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.8450000000000001,
+        "uncertainty": 0.015
+      },
+      "score": {
+        "value": 0.8450000000000001,
+        "uncertainty": 0.015
+      }
+    },
+    "runtime_seconds": 1.656676,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-07_quantum_fourier_transform_2bdbe655.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-07_quantum_fourier_transform_2bdbe655.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:07.494405",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.557,
+        "uncertainty": 0.045
+      },
+      "score": {
+        "value": 0.557,
+        "uncertainty": 0.045
+      }
+    },
+    "runtime_seconds": 9.070287,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-17_quantum_fourier_transform_04965135.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-17_quantum_fourier_transform_04965135.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:17.222897",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.154,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.154,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.798656,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-27_quantum_fourier_transform_98ac67da.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-27_quantum_fourier_transform_98ac67da.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:27.873611",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.026,
+        "uncertainty": 0.008
+      },
+      "score": {
+        "value": 0.026,
+        "uncertainty": 0.008
+      }
+    },
+    "runtime_seconds": 1.810974,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-37_quantum_fourier_transform_21a9658a.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-37_quantum_fourier_transform_21a9658a.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:37.703266",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.002,
+        "uncertainty": 0.001
+      },
+      "score": {
+        "value": 0.002,
+        "uncertainty": 0.001
+      }
+    },
+    "runtime_seconds": 1.861706,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-48_quantum_fourier_transform_ca6415f2.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-48_quantum_fourier_transform_ca6415f2.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:48.387158",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 1.875118,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-58_quantum_fourier_transform_9843859b.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-29-58_quantum_fourier_transform_9843859b.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:29:58.901555",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 1.992088,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-30-09_quantum_fourier_transform_3f71d007.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-30-09_quantum_fourier_transform_3f71d007.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:30:09.858030",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.143241,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-30-20_quantum_fourier_transform_e77ede3f.json
+++ b/metriq-gym/v0.6/ibm/ibm_kingston/2026-02-09_14-30-20_quantum_fourier_transform_e77ede3f.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:30:20.455925",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.360334,
+    "platform": {
+      "device": "ibm_kingston",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.0"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-06_quantum_fourier_transform_5edc1a4f.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-06_quantum_fourier_transform_5edc1a4f.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:06.204809",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.969,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.969,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.892837,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-16_quantum_fourier_transform_03ab6288.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-16_quantum_fourier_transform_03ab6288.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:16.134727",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.717,
+        "uncertainty": 0.02
+      },
+      "score": {
+        "value": 0.717,
+        "uncertainty": 0.02
+      }
+    },
+    "runtime_seconds": 1.878065,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-25_quantum_fourier_transform_83309bb4.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-25_quantum_fourier_transform_83309bb4.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:25.861274",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.413,
+        "uncertainty": 0.024
+      },
+      "score": {
+        "value": 0.413,
+        "uncertainty": 0.024
+      }
+    },
+    "runtime_seconds": 2.113731,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-36_quantum_fourier_transform_0e80c27d.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-36_quantum_fourier_transform_0e80c27d.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:36.831865",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.136,
+        "uncertainty": 0.031
+      },
+      "score": {
+        "value": 0.136,
+        "uncertainty": 0.031
+      }
+    },
+    "runtime_seconds": 1.947733,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-47_quantum_fourier_transform_fe6bb6dc.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-47_quantum_fourier_transform_fe6bb6dc.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:47.778907",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.025000000000000005,
+        "uncertainty": 0.01
+      },
+      "score": {
+        "value": 0.025000000000000005,
+        "uncertainty": 0.01
+      }
+    },
+    "runtime_seconds": 2.00434,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-58_quantum_fourier_transform_478399f8.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-34-58_quantum_fourier_transform_478399f8.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:34:58.141381",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0030000000000000005,
+        "uncertainty": 0.001
+      },
+      "score": {
+        "value": 0.0030000000000000005,
+        "uncertainty": 0.001
+      }
+    },
+    "runtime_seconds": 2.29482,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-09_quantum_fourier_transform_29fdbb4a.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-09_quantum_fourier_transform_29fdbb4a.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:35:09.485023",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.15866,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-20_quantum_fourier_transform_71181fd5.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-20_quantum_fourier_transform_71181fd5.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:35:20.545457",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.466135,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-32_quantum_fourier_transform_a17ab3b8.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-32_quantum_fourier_transform_a17ab3b8.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:35:32.116269",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.422065,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-43_quantum_fourier_transform_d4fde6a9.json
+++ b/metriq-gym/v0.6/ibm/ibm_marrakesh/2026-02-09_14-35-43_quantum_fourier_transform_d4fde6a9.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:35:43.223365",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.543615,
+    "platform": {
+      "device": "ibm_marrakesh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.20"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-30_quantum_fourier_transform_c86bc29c.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-30_quantum_fourier_transform_c86bc29c.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:30:30.748038",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.9579999999999999,
+        "uncertainty": 0.004
+      },
+      "score": {
+        "value": 0.9579999999999999,
+        "uncertainty": 0.004
+      }
+    },
+    "runtime_seconds": 1.712388,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-40_quantum_fourier_transform_90855144.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-40_quantum_fourier_transform_90855144.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:30:40.988920",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.828,
+        "uncertainty": 0.008
+      },
+      "score": {
+        "value": 0.828,
+        "uncertainty": 0.008
+      }
+    },
+    "runtime_seconds": 1.688973,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-50_quantum_fourier_transform_6281aa30.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-30-50_quantum_fourier_transform_6281aa30.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:30:50.921211",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.615,
+        "uncertainty": 0.013
+      },
+      "score": {
+        "value": 0.615,
+        "uncertainty": 0.013
+      }
+    },
+    "runtime_seconds": 1.672242,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-00_quantum_fourier_transform_8f26d7a6.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-00_quantum_fourier_transform_8f26d7a6.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:00.752073",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.36800000000000005,
+        "uncertainty": 0.023
+      },
+      "score": {
+        "value": 0.36800000000000005,
+        "uncertainty": 0.023
+      }
+    },
+    "runtime_seconds": 1.760702,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-10_quantum_fourier_transform_0daac786.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-10_quantum_fourier_transform_0daac786.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:10.688368",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.08600000000000001,
+        "uncertainty": 0.01
+      },
+      "score": {
+        "value": 0.08600000000000001,
+        "uncertainty": 0.01
+      }
+    },
+    "runtime_seconds": 1.840726,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-20_quantum_fourier_transform_82fa8028.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-20_quantum_fourier_transform_82fa8028.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:20.823899",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.004,
+        "uncertainty": 0.002
+      },
+      "score": {
+        "value": 0.004,
+        "uncertainty": 0.002
+      }
+    },
+    "runtime_seconds": 1.941467,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-31_quantum_fourier_transform_a4679b12.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-31_quantum_fourier_transform_a4679b12.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:31.242747",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 1.988037,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-42_quantum_fourier_transform_ad66b5fa.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-42_quantum_fourier_transform_ad66b5fa.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:42.125515",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.11027,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-53_quantum_fourier_transform_a428100d.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-31-53_quantum_fourier_transform_a428100d.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:31:53.490659",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.240705,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-32-04_quantum_fourier_transform_6030e375.json
+++ b/metriq-gym/v0.6/ibm/ibm_pittsburgh/2026-02-09_14-32-04_quantum_fourier_transform_6030e375.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:32:04.240817",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.387747,
+    "platform": {
+      "device": "ibm_pittsburgh",
+      "device_metadata": {
+        "num_qubits": 156,
+        "simulator": false,
+        "version": "1.0.15"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-43-56_quantum_fourier_transform_1c28c3ab.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-43-56_quantum_fourier_transform_1c28c3ab.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:43:56.202415",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.198244,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 16,
+      "method": 1,
+      "min_qubits": 16,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-44-07_quantum_fourier_transform_5969d9e8.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-44-07_quantum_fourier_transform_5969d9e8.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:44:07.766742",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.466743,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 20,
+      "method": 1,
+      "min_qubits": 20,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-46-53_quantum_fourier_transform_04bf7865.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-46-53_quantum_fourier_transform_04bf7865.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:46:53.253102",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.948,
+        "uncertainty": 0.004
+      },
+      "score": {
+        "value": 0.948,
+        "uncertainty": 0.004
+      }
+    },
+    "runtime_seconds": 1.648003,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 2,
+      "method": 1,
+      "min_qubits": 2,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-03_quantum_fourier_transform_25164dd5.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-03_quantum_fourier_transform_25164dd5.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:03.287725",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.8080000000000002,
+        "uncertainty": 0.009
+      },
+      "score": {
+        "value": 0.8080000000000002,
+        "uncertainty": 0.009
+      }
+    },
+    "runtime_seconds": 2.227245,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 4,
+      "method": 1,
+      "min_qubits": 4,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-14_quantum_fourier_transform_d661d8a8.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-14_quantum_fourier_transform_d661d8a8.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:14.501962",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.553,
+        "uncertainty": 0.002
+      },
+      "score": {
+        "value": 0.553,
+        "uncertainty": 0.002
+      }
+    },
+    "runtime_seconds": 1.682946,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 6,
+      "method": 1,
+      "min_qubits": 6,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-24_quantum_fourier_transform_e1804ef3.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-24_quantum_fourier_transform_e1804ef3.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:24.485055",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.215,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.215,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.78716,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 8,
+      "method": 1,
+      "min_qubits": 8,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-34_quantum_fourier_transform_3dc5e18d.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-34_quantum_fourier_transform_3dc5e18d.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:34.629178",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.054,
+        "uncertainty": 0.003
+      },
+      "score": {
+        "value": 0.054,
+        "uncertainty": 0.003
+      }
+    },
+    "runtime_seconds": 1.853811,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 10,
+      "method": 1,
+      "min_qubits": 10,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-44_quantum_fourier_transform_56a4ce07.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-44_quantum_fourier_transform_56a4ce07.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:44.762753",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.002,
+        "uncertainty": 0.001
+      },
+      "score": {
+        "value": 0.002,
+        "uncertainty": 0.001
+      }
+    },
+    "runtime_seconds": 1.918084,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 12,
+      "method": 1,
+      "min_qubits": 12,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-54_quantum_fourier_transform_7894aac7.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_13-47-54_quantum_fourier_transform_7894aac7.json
@@ -1,0 +1,38 @@
+[
+  {
+    "app_version": "0.6.2.dev13+gd0c1487e5.d20260209",
+    "timestamp": "2026-02-09T13:47:54.901502",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.04159,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "max_qubits": 14,
+      "method": 1,
+      "min_qubits": 14,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]

--- a/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_14-26-54_quantum_fourier_transform_22c28b81.json
+++ b/metriq-gym/v0.6/ibm/ibm_torino/2026-02-09_14-26-54_quantum_fourier_transform_22c28b81.json
@@ -1,0 +1,39 @@
+[
+  {
+    "app_version": "0.6.2.dev15+g326cb359f",
+    "timestamp": "2026-02-09T14:26:54.554959",
+    "suite_id": null,
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "runtime_seconds": 2.365744,
+    "platform": {
+      "device": "ibm_torino",
+      "device_metadata": {
+        "num_qubits": 133,
+        "simulator": false,
+        "version": "1.0.107"
+      },
+      "provider": "ibm"
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "error_mitigation": [],
+      "max_circuits": 3,
+      "max_qubits": 18,
+      "method": 1,
+      "min_qubits": 18,
+      "shots": 1000,
+      "skip_qubits": 1,
+      "use_midcircuit_measurement": false
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- Consolidates 60 metriq-gym Quantum Fourier Transform uploads into one reviewable change.
- Adds ten runs each for IBM Torino, Boston, Kingston, Pittsburgh, Fez, and Marrakesh.
- These benchmark results were collected to generate a graph for the Metriq paper.
- Preserves vprusso's authorship and records the original source commit on every cherry-picked commit.

## Validation

- `python3.13 scripts/aggregate.py` — processed 344 rows across 20 platforms from 301 files.
- `uv run --python 3.13 --with pytest pytest` — 5 tests passed.
- All 60 added files parse as JSON, and no source paths overlap each other or current `main`.

## Superseded pull requests

#300, #301, #302, #303, #304, #305, #306, #307, #308, #309, #310, #311, #312, #313, #314, #315, #316, #317, #318, #319, #320, #321, #322, #323, #324, #325, #326, #327, #328, #329, #330, #331, #332, #333, #334, #335, #336, #337, #338, #339, #340, #341, #342, #343, #344, #345, #346, #347, #348, #349, #350, #351, #352, #353, #354, #355, #356, #357, #358, #359

