### PR TITLE
mgym upload: Mirror Circuits (w=8, d=64) on IQM Emerald

### DIFF
--- a/metriq-gym/v0.7/aws/iqm_emerald/2026-08-07_10-00-04_mirror_circuits_5d8f6d26.json
+++ b/metriq-gym/v0.7/aws/iqm_emerald/2026-08-07_10-00-04_mirror_circuits_5d8f6d26.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-07T10:00:04.216878",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0038,
+        "uncertainty": 0.0006152690468404858
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "iqm_emerald",
+      "device_metadata": {
+        "num_qubits": 54,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        240,
+        218,
+        218,
+        194,
+        192,
+        220,
+        214,
+        220,
+        190,
+        206
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        240,
+        218,
+        218,
+        194,
+        192,
+        220,
+        214,
+        220,
+        190,
+        206
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 64,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 8
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=8, d=64) on IQM Emerald via the standard metriq-gym workflow (no verbatim mode): polarization 0.0; raw success probability 0.0038 ≈ the 2^-8 random baseline.
