### PR TITLE
mgym upload: Mirror Circuits (w=16, d=32) on IQM Emerald

### DIFF
--- a/metriq-gym/v0.7/aws/iqm_emerald/2026-08-07_10-17-24_mirror_circuits_5159e49c.json
+++ b/metriq-gym/v0.7/aws/iqm_emerald/2026-08-07_10-17-24_mirror_circuits_5159e49c.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-07T10:17:24.325491",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "iqm_emerald",
+      "device_metadata": {
+        "num_qubits": 54,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        200,
+        230,
+        252,
+        188,
+        212,
+        218,
+        228,
+        198,
+        212,
+        192
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        200,
+        230,
+        252,
+        188,
+        212,
+        218,
+        228,
+        198,
+        212,
+        192
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 32,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 16
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=16, d=32) on IQM Emerald via the standard metriq-gym workflow (no verbatim mode): polarization 0.0, success probability 0.0.
