### PR TITLE
mgym upload: QFT 4q (metriq_score_1_0) on Rigetti Cepheus-1-108Q

### DIFF
--- a/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-05_07-07-05_quantum_fourier_transform_e2941c25.json
+++ b/metriq-gym/v0.7/aws/rigetti_cepheus-1-108q/2026-08-05_07-07-05_quantum_fourier_transform_e2941c25.json
@@ -1,0 +1,50 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b",
+    "timestamp": "2026-08-05T07:07:05.578566",
+    "suite_id": "70b86718-c3e9-49f9-adb3-2db2068422d8",
+    "job_type": "Quantum Fourier Transform",
+    "results": {
+      "accuracy_score": {
+        "value": 0.05000000000000001,
+        "uncertainty": 0.011
+      },
+      "score": {
+        "value": 0.05000000000000001,
+        "uncertainty": 0.011
+      }
+    },
+    "suite": {
+      "id": "70b86718-c3e9-49f9-adb3-2db2068422d8",
+      "name": "metriq_score_1_0"
+    },
+    "platform": {
+      "device": "rigetti_cepheus-1-108q",
+      "device_metadata": {
+        "num_qubits": 107,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        12,
+        12,
+        12
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        12,
+        12,
+        12
+      ]
+    },
+    "params": {
+      "benchmark_name": "Quantum Fourier Transform",
+      "max_circuits": 3,
+      "method": 1,
+      "num_qubits": 4,
+      "shots": 1000,
+      "use_midcircuit_measurement": false
+    }
+  }
+]


### PR DESCRIPTION
QFT 4-qubit datapoint from the metriq_score_1_0 suite on `arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q`.

Part of unitaryfoundation/metriq-data#443. Note: the 12q and 20q QFT jobs from the same suite dispatch fail in Rigetti's server-side compilation (barrier handling, see issue discussion); per the Metriq Score methodology, missing scale datapoints count as zero in aggregation, so only the completed 4q/8q results are uploaded.