### PR TITLE
mgym upload: Mirror Circuits (w=8, d=64) on IQM Garnet

### DIFF
--- a/metriq-gym/v0.7/aws/iqm_garnet/2026-08-07_10-37-06_mirror_circuits_e402e6ae.json
+++ b/metriq-gym/v0.7/aws/iqm_garnet/2026-08-07_10-37-06_mirror_circuits_e402e6ae.json
@@ -1,0 +1,66 @@
+[
+  {
+    "app_version": "0.7.2.dev10+g5bc076b.d20260804",
+    "timestamp": "2026-08-07T10:37:06.163005",
+    "suite_id": null,
+    "job_type": "Mirror Circuits",
+    "results": {
+      "success_probability": {
+        "value": 0.0036,
+        "uncertainty": 0.0005989190262464534
+      },
+      "polarization": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      },
+      "binary_success": false,
+      "score": {
+        "value": 0.0,
+        "uncertainty": 0.0
+      }
+    },
+    "platform": {
+      "device": "iqm_garnet",
+      "device_metadata": {
+        "num_qubits": 20,
+        "simulator": false
+      },
+      "provider": "aws"
+    },
+    "circuit_metadata": {
+      "input_two_qubit_gate_counts": [
+        206,
+        202,
+        186,
+        224,
+        216,
+        220,
+        186,
+        214,
+        218,
+        224
+      ],
+      "transpiled_two_qubit_gate_counts": [
+        206,
+        202,
+        186,
+        224,
+        216,
+        220,
+        186,
+        214,
+        218,
+        224
+      ]
+    },
+    "params": {
+      "benchmark_name": "Mirror Circuits",
+      "num_circuits": 10,
+      "num_layers": 64,
+      "shots": 1000,
+      "two_qubit_gate_name": "CNOT",
+      "two_qubit_gate_prob": 0.5,
+      "width": 8
+    }
+  }
+]


### PR DESCRIPTION
Mirror Circuits (w=8, d=64) on IQM Garnet via the standard metriq-gym workflow (no verbatim mode): polarization 0.0; raw success probability 0.0036 ≈ the 2^-8 random baseline.
