### PR TITLE
RFC: outcome-bearing records (error / unsupported / not_applicable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,47 @@ execution path has been discussed and accepted by the maintainers of this datase
 
 Maintainers may close issues or pull requests that fall outside this scope.
 
+## Record outcomes
+
+Every uploaded record describes one benchmark attempt on one device. In addition
+to completed runs with `results`, a record may declare a non-completed `outcome`:
+
+```json
+{
+  "app_version": "0.7.2",
+  "timestamp": "2026-08-07T12:00:00",
+  "job_type": "Linear Ramp QAOA",
+  "params": { "benchmark_name": "Linear Ramp QAOA", "num_qubits": 100, "...": "..." },
+  "platform": { "provider": "aws", "device": "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q" },
+  "outcome": "unsupported",
+  "outcome_detail": {
+    "reason": "Compiler rejects 100-qubit LR-QAOA circuits on this device",
+    "error_message": "<verbatim provider/compiler error>",
+    "source": "dispatch"
+  },
+  "results": null
+}
+```
+
+- `outcome` is one of `completed`, `error`, `unsupported`, `not_applicable`.
+  A record without the field is a completed run — all records predating the
+  field are.
+- `error` means the attempt failed (possibly transiently); `unsupported` means
+  the device structurally cannot run this benchmark instance (e.g. a compiler
+  restriction) — a human classification, ideally promoted from a captured
+  error; `not_applicable` means the benchmark does not apply to the device
+  category. Machines should only ever record `error`; the other two are
+  asserted by the submitter and reviewed like any data PR.
+- `params` must be populated exactly as for a completed run — they identify
+  which benchmark instance the claim is about.
+- A completed record always supersedes outcome records for the same instance;
+  among outcome records, the latest wins. Outcomes are point-in-time claims:
+  if a device or compiler later supports the run, uploading the successful
+  result retires the claim with no cleanup needed.
+- Scoring is unchanged: non-completed records contribute no value, and
+  component weights stay in the Metriq Score denominator either way. Outcomes
+  affect how coverage is displayed, not how scores are computed.
+
 ## Aggregation and Scoring
 
 - Run `python3 scripts/aggregate.py` (or `python3.13 scripts/aggregate.py`) to generate aggregated results.

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -149,11 +149,43 @@ def _inject_default_metric_directions(out: dict[str, Any], row: dict[str, Any]) 
         out["directions"] = directions
 
 
+# Run outcomes a record may declare. A record without an outcome field is a
+# completed run (every record predating the field is one), so "completed" is
+# implied rather than stamped. Non-completed outcomes carry no results; they
+# are first-class evidence that an attempt errored or that a device cannot run
+# the benchmark instance, and a later completed record supersedes them.
+RECORD_OUTCOMES = frozenset({"completed", "error", "unsupported", "not_applicable"})
+
+
+def _normalize_outcome(row: dict[str, Any]) -> tuple[str | None, dict[str, str] | None]:
+    raw = row.get("outcome")
+    if not isinstance(raw, str):
+        return None, None
+    outcome = raw.strip().lower()
+    if outcome not in RECORD_OUTCOMES or outcome == "completed":
+        return None, None
+
+    detail_raw = row.get("outcome_detail")
+    detail: dict[str, str] = {}
+    if isinstance(detail_raw, dict):
+        for key in ("reason", "error_message", "source", "source_url"):
+            value = detail_raw.get(key)
+            if isinstance(value, str) and value.strip():
+                detail[key] = value.strip()
+    return outcome, detail or None
+
+
 def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k in ("app_version", "timestamp", "provider", "suite_id", "device", "job_type", "results", "params"):
         if k in row:
             out[k] = row[k]
+
+    outcome, outcome_detail = _normalize_outcome(row)
+    if outcome is not None:
+        out["outcome"] = outcome
+        if outcome_detail is not None:
+            out["outcome_detail"] = outcome_detail
 
     platform = row.get("platform")
     device_metadata = None

--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -183,7 +183,7 @@ def flatten_row(row: dict[str, Any]) -> dict[str, Any]:
 
     outcome, outcome_detail = _normalize_outcome(row)
     if outcome is not None:
-        out["outcome"] = outcome
+        out["outcome"], out["results"] = outcome, None
         if outcome_detail is not None:
             out["outcome_detail"] = outcome_detail
 

--- a/tests/test_record_outcomes.py
+++ b/tests/test_record_outcomes.py
@@ -80,6 +80,14 @@ class RecordOutcomeTests(unittest.TestCase):
         self.assertEqual(out["outcome"], "unsupported")
         self.assertNotIn("outcome_detail", out)
 
+    def test_non_completed_outcomes_drop_results_payloads(self):
+        out = flatten_row(
+            outcome_record(outcome="error", results={"score": {"value": 1.23, "uncertainty": 0.01}})
+        )
+        self.assertEqual(out["outcome"], "error")
+        self.assertIn("results", out)
+        self.assertIsNone(out["results"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_record_outcomes.py
+++ b/tests/test_record_outcomes.py
@@ -1,0 +1,85 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from etl import flatten_row  # noqa: E402
+
+
+CEPHEUS_ARN = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
+
+
+def outcome_record(**overrides):
+    record = {
+        "app_version": "0.7.2",
+        "timestamp": "2026-08-07T12:00:00",
+        "job_type": "Linear Ramp QAOA",
+        "params": {"benchmark_name": "Linear Ramp QAOA", "num_qubits": 100},
+        "platform": {"provider": "braket", "device": CEPHEUS_ARN},
+        "outcome": "unsupported",
+        "outcome_detail": {
+            "reason": "Compiler rejects 100-qubit LR-QAOA circuits",
+            "error_message": "compilation failed: too many qubits in routing",
+            "source": "dispatch",
+        },
+        "results": None,
+    }
+    record.update(overrides)
+    return record
+
+
+class RecordOutcomeTests(unittest.TestCase):
+    def test_outcome_and_detail_pass_through(self):
+        out = flatten_row(outcome_record())
+        self.assertEqual(out["outcome"], "unsupported")
+        self.assertEqual(
+            out["outcome_detail"]["reason"], "Compiler rejects 100-qubit LR-QAOA circuits"
+        )
+        self.assertEqual(out["outcome_detail"]["source"], "dispatch")
+        self.assertEqual(out["provider"], "aws")
+        self.assertEqual(out["device"], "rigetti_cepheus-1-108q")
+        self.assertEqual(out["params"]["num_qubits"], 100)
+
+    def test_completed_outcome_is_implied_not_stamped(self):
+        out = flatten_row(outcome_record(outcome="completed"))
+        self.assertNotIn("outcome", out)
+        self.assertNotIn("outcome_detail", out)
+
+    def test_records_without_outcome_are_unchanged(self):
+        out = flatten_row(
+            {
+                "timestamp": "2026-08-07T12:00:00",
+                "job_type": "WIT",
+                "platform": {"provider": "ibm", "device": "ibm_fez"},
+                "results": {"score": {"value": 88.4, "uncertainty": 0.1}},
+            }
+        )
+        self.assertNotIn("outcome", out)
+        self.assertEqual(out["results"]["score"], 88.4)
+
+    def test_unknown_outcome_values_are_dropped(self):
+        out = flatten_row(outcome_record(outcome="exploded"))
+        self.assertNotIn("outcome", out)
+        self.assertNotIn("outcome_detail", out)
+
+    def test_outcome_detail_is_normalized(self):
+        out = flatten_row(
+            outcome_record(
+                outcome="  ERROR ",
+                outcome_detail={"reason": "  queue died  ", "unknown_key": "x", "source": ""},
+            )
+        )
+        self.assertEqual(out["outcome"], "error")
+        self.assertEqual(out["outcome_detail"], {"reason": "queue died"})
+
+    def test_outcome_without_detail(self):
+        out = flatten_row(outcome_record(outcome_detail=None))
+        self.assertEqual(out["outcome"], "unsupported")
+        self.assertNotIn("outcome_detail", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Today a benchmark instance on a device is either *submitted* or *absent* — there is no way to record that a run was attempted and failed, or that a device structurally cannot run an instance. Concrete case: LR-QAOA 100q on `rigetti_cepheus-1-108q` — the device has enough qubits, but the compiler rejects the circuit. The Platforms page shows "No submission", which reads as a gap rather than an impossibility.

**The submission itself should carry the outcome to enable manual marking of records as error/unsupported/not_applicable in addition to submitted**. This is then tied to an actual attempt, with params, timestamp, and the captured error, flowing through the same PR review as results, and automatically superseded when a later run succeeds.

## Schema change (this PR)

A record may declare `"outcome": "completed" | "error" | "unsupported" | "not_applicable"`, plus an optional `outcome_detail` (`reason`, `error_message`, `source`, `source_url`). See the new **Record outcomes** section in the README for full semantics. Key points:

- **Absent `outcome` = completed.** Every existing record is unaffected; no migration.
- **`params` are populated exactly as for a completed run** — they identify which benchmark instance the claim is about, using the machinery that already exists.
- **Vocabulary**: `error` = the attempt failed (possibly transient; machine-recorded). `unsupported` = the device structurally cannot run this instance (human classification, ideally promoted from a captured error). `not_applicable` = the benchmark doesn't apply to the device category.
- **Supersession**: a completed record always beats outcome records for the same instance; among outcome records, latest wins. A later successful run retires the claim with no cleanup.
- **Scoring is unchanged**: non-completed records contribute no numerator value and component weights stay in the Metriq Score denominator. Otherwise classifying failures as "unsupported" would inflate scores. (Whether `not_applicable` should ever be excluded from the denominator is deliberately out of scope — it changes cross-device comparability and deserves its own discussion.)

Included here: README contract docs, ETL normalization/pass-through of the fields into `benchmark.latest.json` (unknown values dropped), and tests. Verified against the full dataset: `aggregate.py` output is identical for all existing records (SHA-256 of `benchmark.latest.json`, excluding the volatile `generated_at` stamps, matches between main and this branch).

## Follow-up changes across the repos (for discussion)

**metriq-data (phase 2, after this lands):** `score.py` stamps the winning outcome record onto the component breakdown (`reported_outcome`, reason, timestamp) so platform pages can render it. Optional: PR-validation check that `outcome` records have null `results` and vice versa.

**metriq-gym:** persist captured dispatch/poll errors on the job record (today they're discarded); allow `mgym job upload` on failed jobs, producing an `outcome: "error"` record with the captured message; add `mgym job upload <id> --outcome unsupported --reason "..."` for human reclassification. The Cepheus workflow becomes: dispatch LR-QAOA 100q → compiler rejects it → upload that job as `unsupported` with the verbatim error attached as evidence.

**metriq-web:** platform detail Status column grows from Submitted / Not supported (qubit-count) / No submission to also render reported outcomes — "Not supported", "Error reported", "N/A" — with reason, date, and error text in the tooltip, framed "as of <date>" since these are point-in-time claims. Coverage counts move reported-unsupported/n-a out of the runnable denominator (display only); `error` stays in "runnable but not covered". The Results table shows an outcome chip where the score would be; the existing record dedupe already prefers scored records, so completed runs supersede outcome rows in both toggle modes for free.

Rollout order: this PR → metriq-gym upload path → score.py stamping → metriq-web display. Each step is independently shippable and old clients never notice.

What do you think of the vocabulary and the scoring policy? @cosenal @vprusso @Changhao-Li