### PR TITLE
Derive required_num_qubits from width selectors and explicit config

### DIFF
--- a/scripts/score.py
+++ b/scripts/score.py
@@ -939,12 +939,21 @@ def compute_device_composite_scores(
                 "raw_timestamp": raw_ts,
             }
 
-            # Surface a structural qubit requirement when the component selects a
-            # fixed qubit count. This lets the UI tell a benchmark a device cannot
-            # run (device qubits below the requirement) apart from one that is
-            # simply missing a submission.
-            if isinstance(selector, dict) and isinstance(selector.get("num_qubits"), int):
-                breakdown[label]["required_num_qubits"] = selector["num_qubits"]
+            # Surface a structural qubit requirement so the UI can tell a
+            # benchmark a device cannot run (device qubits below the
+            # requirement) apart from one that is simply missing a submission.
+            # Priority: an explicit required_num_qubits on the component config
+            # (for components whose size lives in the metric name, like
+            # EPLG-100), then a num_qubits selector, then a width selector
+            # (Mirror Circuits, where width is the qubit count).
+            required = comp.get("required_num_qubits")
+            if not isinstance(required, int) and isinstance(selector, dict):
+                for key in ("num_qubits", "width"):
+                    if isinstance(selector.get(key), int):
+                        required = selector[key]
+                        break
+            if isinstance(required, int):
+                breakdown[label]["required_num_qubits"] = required
 
         # Denominator is the sum of all defined weights; missing components
         # contribute 0 to the numerator but still count in the denominator.

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -170,24 +170,28 @@
               {
                 "benchmark": "EPLG",
                 "metric": "eplg_10",
+                "required_num_qubits": 10,
                 "label": "EPLG-10:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
                 "metric": "eplg_20",
+                "required_num_qubits": 20,
                 "label": "EPLG-20:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
                 "metric": "eplg_50",
+                "required_num_qubits": 50,
                 "label": "EPLG-50:score",
                 "weight": "1/4"
               },
               {
                 "benchmark": "EPLG",
                 "metric": "eplg_100",
+                "required_num_qubits": 100,
                 "label": "EPLG-100:score",
                 "weight": "1/4"
               }
@@ -380,24 +384,28 @@
             {
               "benchmark": "EPLG",
               "metric": "eplg_10",
+              "required_num_qubits": 10,
               "label": "EPLG-10",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_20",
+              "required_num_qubits": 20,
               "label": "EPLG-20",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_50",
+              "required_num_qubits": 50,
               "label": "EPLG-50",
               "weight": "1/4"
             },
             {
               "benchmark": "EPLG",
               "metric": "eplg_100",
+              "required_num_qubits": 100,
               "label": "EPLG-100",
               "weight": "1/4"
             }

--- a/tests/test_provider_aliases.py
+++ b/tests/test_provider_aliases.py
@@ -18,6 +18,7 @@ from etl import (  # noqa: E402
     write_platform_outputs,
 )
 from score import (  # noqa: E402
+    compute_device_composite_scores,
     _baseline_provider_device_for_series,
     baseline_metadata_for_latest_series,
 )
@@ -130,6 +131,65 @@ class ProviderAliasTests(unittest.TestCase):
 
 
 class PlatformCatalogTests(unittest.TestCase):
+    def test_component_required_num_qubits_sources(self):
+        """required_num_qubits comes from explicit config, num_qubits, or width selectors."""
+        scoring_cfg = {
+            "default": {
+                "composite": {
+                    "components": [
+                        {
+                            "label": "G",
+                            "weight": "1/1",
+                            "components": [
+                                {
+                                    "benchmark": "B",
+                                    "metric": "m",
+                                    "selector": {"num_qubits": 10},
+                                    "label": "by-num-qubits",
+                                    "weight": "1/4",
+                                },
+                                {
+                                    "benchmark": "B",
+                                    "metric": "m",
+                                    "selector": {"width": 128, "num_layers": 2},
+                                    "label": "by-width",
+                                    "weight": "1/4",
+                                },
+                                {
+                                    "benchmark": "B",
+                                    "metric": "m2",
+                                    "required_num_qubits": 100,
+                                    "label": "explicit",
+                                    "weight": "1/4",
+                                },
+                                {
+                                    "benchmark": "B",
+                                    "metric": "m3",
+                                    "label": "no-requirement",
+                                    "weight": "1/4",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+        row = {
+            "provider": "prov",
+            "device": "dev",
+            "timestamp": "2026-07-15T16:26:08",
+            "params": {"benchmark_name": "B", "num_qubits": 10},
+            "results": {"m": {"value": 0.5}},
+        }
+        records = compute_device_composite_scores(
+            [row], {id(row): "v0.7"}, {}, scoring_cfg
+        )
+        comps = records[0]["components"]
+        self.assertEqual(comps["by-num-qubits"]["required_num_qubits"], 10)
+        self.assertEqual(comps["by-width"]["required_num_qubits"], 128)
+        self.assertEqual(comps["explicit"]["required_num_qubits"], 100)
+        self.assertNotIn("required_num_qubits", comps["no-requirement"])
+
     def test_ankaa_3_is_retired(self):
         catalog = load_platform_catalog(str(REPO_ROOT))
         platform_key = ("aws", "rigetti_ankaa-3")


### PR DESCRIPTION
Fixes the classification gap cosenal found on unitaryfoundation/metriq-web#24: on H2-2 (56 qubits), Linear Ramp QAOA (100q) showed as not supported while Mirror Circuits (w=128,d=2) and EPLG-100 showed as missing submissions, even though none of the three can run there.

## Cause

#473 derived `required_num_qubits` only from a `num_qubits` selector. Mirror Circuits selects on `width` (which is its qubit count), and EPLG has no selector at all, its chain length lives in the metric name (`eplg_100`), so neither carried a requirement and the UI fell back to treating them as runnable.

## Change

Resolution order for the emitted `required_num_qubits`: an explicit `required_num_qubits` on the component config, then a `num_qubits` selector, then a `width` selector. `scoring.json` gains the explicit values for EPLG 10/20/50/100 in both the `default` and `v0.4` blocks.

## Validation

Ran `aggregate.py` and classified the regenerated output with the same logic the frontend uses. H2-2 (56 qubits) now marks Mirror Circuits w=64 and w=128 and EPLG-100 as not supported, matching LR-QAOA-100. iqm_garnet (20 qubits) additionally marks Mirror Circuits w=24 through w=128 and QMLK-30/50 and LR-QAOA-50/100.

One data wrinkle surfaced while checking: garnet has `eplg_50`/`eplg_100` values despite its record's `chain_lengths` topping out at 18, all three duplicating the longest-chain value. That is padding from an older metriq-gym version (current `main` uses `.get(N, None)`), so those components display as submitted because data exists. Truthful to the record, but the record itself is misleading; separate cleanup, not blocked on this.
