### PR TITLE
Backfill negative LR-QAOA values to zero

### DIFF
--- a/metriq-gym/v0.6/origin/wukong_72/2026-02-24_13-18-23_linear_ramp_qaoa_fa544c4d.json
+++ b/metriq-gym/v0.6/origin/wukong_72/2026-02-24_13-18-23_linear_ramp_qaoa_fa544c4d.json
@@ -13,10 +13,10 @@
         false
       ],
       "effective_approx_ratio": [
-        -0.0349563502846115
+        0.0
       ],
       "score": {
-        "value": -0.0349563502846115,
+        "value": 0.0,
         "uncertainty": null
       }
     },

--- a/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-23_13-12-00_linear_ramp_qaoa_db61cbf0.json
+++ b/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-23_13-12-00_linear_ramp_qaoa_db61cbf0.json
@@ -13,10 +13,10 @@
         true
       ],
       "effective_approx_ratio": [
-        -0.00779446189285339
+        0.0
       ],
       "score": {
-        "value": -0.00779446189285339,
+        "value": 0.0,
         "uncertainty": null
       }
     },

--- a/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-24_10-07-20_linear_ramp_qaoa_a1c0bf7c.json
+++ b/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-24_10-07-20_linear_ramp_qaoa_a1c0bf7c.json
@@ -13,10 +13,10 @@
         true
       ],
       "effective_approx_ratio": [
-        -0.002039076888062319
+        0.0
       ],
       "score": {
-        "value": -0.002039076888062319,
+        "value": 0.0,
         "uncertainty": null
       }
     },

--- a/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-24_10-11-44_linear_ramp_qaoa_ae9ba470.json
+++ b/metriq-gym/v0.7/braket/arn_aws_braket_us-west-1_device_qpu_rigetti_cepheus-1-108q/2026-07-24_10-11-44_linear_ramp_qaoa_ae9ba470.json
@@ -13,10 +13,10 @@
         false
       ],
       "effective_approx_ratio": [
-        -0.029157400262725435
+        0.0
       ],
       "score": {
-        "value": -0.029157400262725435,
+        "value": 0.0,
         "uncertainty": null
       }
     },


### PR DESCRIPTION
Fixes #520.

Scanned all 41 LR-QAOA result files; 4 had a negative `effective_approx_ratio` (and matching `score.value`), which happens when the measured approximation ratio falls below the random-sampling baseline. Those values are now 0, consistent with the flooring added in unitaryfoundation/metriq-gym#791.

| File | Old value |
|---|---|
| `v0.6/origin/wukong_72/2026-02-24_13-18-23_...fa544c4d.json` | -0.0350 |
| `v0.7/braket/...rigetti_cepheus-1-108q/2026-07-23_13-12-00_...db61cbf0.json` | -0.0078 |
| `v0.7/braket/...rigetti_cepheus-1-108q/2026-07-24_10-07-20_...a1c0bf7c.json` | -0.0020 |
| `v0.7/braket/...rigetti_cepheus-1-108q/2026-07-24_10-11-44_...ae9ba470.json` | -0.0292 |

Only the numeric values changed (8 lines total); no reformatting.