### PR TITLE
Aggregate raw values across widths before baseline normalization

### DIFF
--- a/scripts/score.py
+++ b/scripts/score.py
@@ -792,6 +792,66 @@ def _get_normalized_metric_value(
     return None
 
 
+def _get_baseline_metric_value(
+    row: dict[str, Any],
+    metric: str,
+    series_label: str | None,
+    selector_fp: str,
+    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
+) -> float | None:
+    """Return the baseline device's raw value for the same (benchmark, metric, selector).
+
+    This is the denominator that _get_normalized_metric_value would use. It is
+    exposed separately so composite scoring can aggregate raw values across
+    circuit widths before normalizing.
+    """
+    bench = derive_benchmark_name(row)
+    baseline_avg = baseline_avg_by_series.get(series_label or "", {})
+    base = baseline_avg.get((bench, metric, selector_fp))
+    if base is None:
+        base = _fallback_baseline_average(
+            series_label, bench, metric, selector_fp, baseline_avg_by_series
+        )
+    return base
+
+
+def _metric_direction(row: dict[str, Any], metric: str) -> str:
+    dir_map = row.get("directions") if isinstance(row.get("directions"), dict) else {}
+    return str(dir_map.get(metric, "higher")).lower()
+
+
+def _benchmark_subscore(
+    items: list[dict[str, Any]],
+) -> tuple[float, float] | None:
+    """Benchmark subscore from width-aggregated raw values, with its present sub-weight.
+
+    Aggregates the raw measurements across circuit widths first and normalizes the
+    aggregate against the baseline, rather than normalizing each width separately
+    and averaging the ratios. A single width whose baseline value sits at the noise
+    floor otherwise produces an arbitrarily large ratio that dominates the composite.
+
+    Returns None when no width has both a device value and a baseline value.
+    """
+    usable = [
+        it
+        for it in items
+        if it["sub_weight"] > 0 and it["raw"] is not None and it["baseline"] is not None
+    ]
+    if not usable:
+        return None
+    device_total = sum(it["sub_weight"] * it["raw"] for it in usable)
+    baseline_total = sum(it["sub_weight"] * it["baseline"] for it in usable)
+    present_sub = sum(it["sub_weight"] for it in usable)
+    lower_is_better = any(it["direction"] == "lower" for it in usable)
+    if lower_is_better:
+        if device_total <= 0:
+            return None
+        return 100.0 * baseline_total / device_total, present_sub
+    if baseline_total <= 0:
+        return None
+    return 100.0 * device_total / baseline_total, present_sub
+
+
 def _get_raw_metric_value(row: dict[str, Any], metric: str) -> float | None:
     """Return the raw metric value from row.results when present, else None."""
     results = row.get("results") if isinstance(row.get("results"), dict) else {}
@@ -879,6 +939,12 @@ def compute_device_composite_scores(
         # Group label -> {"group_weight": float, "items": [(sub_weight, normalized_value | None)]}
         # for groups aggregated with a harmonic mean instead of the default arithmetic sum.
         harmonic_groups: dict[str, dict[str, Any]] = {}
+        # Group label -> {"group_weight": float, "items": [...], "labels": [...]} for groups
+        # aggregated over raw values across circuit widths before baseline normalization.
+        arithmetic_groups: dict[str, dict[str, Any]] = {}
+        # Components with no group (or no usable raw/baseline pair) fall back to the
+        # per-component normalized values.
+        ungrouped: list[tuple[float, float]] = []
 
         for comp in components_flat:
             if not isinstance(comp, dict):
@@ -938,7 +1004,8 @@ def compute_device_composite_scores(
                 normalized_val = _get_normalized_metric_value(
                     r, metric, series_label, selector_fp, baseline_avg_by_series
                 )
-                if normalized_val is not None and _is_baseline_row_for_series(scoring_cfg, series_label, r):
+                is_baseline_row = _is_baseline_row_for_series(scoring_cfg, series_label, r)
+                if normalized_val is not None and is_baseline_row:
                     # Keep baseline components anchored at 100 in platform composites.
                     normalized_val = 100.0
                 raw_val = _get_raw_metric_value(r, metric)
@@ -949,6 +1016,18 @@ def compute_device_composite_scores(
                     r_copy["_normalized_val"] = float(normalized_val)
                 if raw_val is not None:
                     r_copy["_raw_val"] = float(raw_val)
+                    # Anchor the baseline device against its own value so its
+                    # width-aggregated subscores come out at exactly 100.
+                    base_val = (
+                        raw_val
+                        if is_baseline_row
+                        else _get_baseline_metric_value(
+                            r, metric, series_label, selector_fp, baseline_avg_by_series
+                        )
+                    )
+                    if base_val is not None:
+                        r_copy["_baseline_val"] = float(base_val)
+                    r_copy["_direction"] = _metric_direction(r, metric)
                 matches.append(r_copy)
 
             picked_norm, _ = _pick_latest_metric_row(matches, "_normalized_val")
@@ -973,8 +1052,32 @@ def compute_device_composite_scores(
                     group_label, {"group_weight": group_weight, "items": []}
                 )
                 group["items"].append((sub_weight, normalized_value))
+            elif group_label is not None:
+                group = arithmetic_groups.setdefault(
+                    group_label, {"group_weight": group_weight, "items": []}
+                )
+                group["items"].append(
+                    {
+                        "label": label,
+                        "sub_weight": sub_weight,
+                        "weight": weight,
+                        "normalized": normalized_value,
+                        "raw": raw_value,
+                        "baseline": (
+                            float(picked_raw.get("_baseline_val"))
+                            if picked_raw is not None
+                            and picked_raw.get("_baseline_val") is not None
+                            else None
+                        ),
+                        "direction": (
+                            str(picked_raw.get("_direction", "higher"))
+                            if picked_raw is not None
+                            else "higher"
+                        ),
+                    }
+                )
             elif normalized_value is not None:
-                numerator += weight * normalized_value
+                ungrouped.append((weight, normalized_value))
 
             breakdown[label] = {
                 "metric": metric,
@@ -1000,6 +1103,31 @@ def compute_device_composite_scores(
             # simply missing a submission.
             if isinstance(selector, dict) and isinstance(selector.get("num_qubits"), int):
                 breakdown[label]["required_num_qubits"] = selector["num_qubits"]
+
+        for weight, normalized_value in ungrouped:
+            numerator += weight * normalized_value
+
+        # Fold arithmetic groups into the numerator. Following the Metriq Score
+        # definition (arXiv:2603.08680, Eqs. 3-5), the raw measurements are summed
+        # across circuit widths first and the aggregate is normalized against the
+        # baseline once, so a width whose baseline value sits at the noise floor
+        # cannot contribute an unbounded ratio. Missing widths still contribute 0
+        # through the present sub-weight share.
+        for group in arithmetic_groups.values():
+            items = group["items"]
+            total_sub = sum(it["sub_weight"] for it in items if it["sub_weight"] > 0)
+            subscore = _benchmark_subscore(items) if total_sub > 0 else None
+            if subscore is None:
+                # No width has both a device and a baseline raw value (for example
+                # derived metrics such as BSEQ that only carry normalized scores).
+                for it in items:
+                    if it["normalized"] is not None:
+                        numerator += it["weight"] * it["normalized"]
+                continue
+            value, present_sub = subscore
+            numerator += float(group["group_weight"]) * value * (present_sub / total_sub)
+            for it in items:
+                breakdown[it["label"]]["group_subscore"] = value
 
         # Fold harmonic groups into the numerator: the group's score is the
         # weighted harmonic mean of its available components, scaled by the

--- a/tests/test_composite_width_aggregation.py
+++ b/tests/test_composite_width_aggregation.py
@@ -1,0 +1,185 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score import (  # noqa: E402
+    _selector_fingerprint,
+    compute_device_composite_scores,
+)
+
+
+BENCH = "Mirror Circuits"
+SELECTORS = [{"width": 8}, {"width": 64}]
+SUB_WEIGHTS = ["1/9", "8/9"]
+
+
+def _scoring_cfg(aggregation=None, weight="1"):
+    group = {
+        "label": BENCH,
+        "weight": weight,
+        "components": [
+            {
+                "benchmark": BENCH,
+                "metric": "score",
+                "selector": sel,
+                "label": f"{BENCH} (w={sel['width']}):score",
+                "weight": sub,
+            }
+            for sel, sub in zip(SELECTORS, SUB_WEIGHTS)
+        ],
+    }
+    if aggregation:
+        group["aggregation"] = aggregation
+    return {
+        "default": {
+            "baseline": {"provider": "ibm", "device": "base_device"},
+            "composite": {"components": [group]},
+        }
+    }
+
+
+def _row(device, selector, value, direction="higher"):
+    return {
+        "provider": "ibm",
+        "device": device,
+        "timestamp": "2026-01-01T00:00:00",
+        "job_type": BENCH,
+        "params": dict(selector),
+        "results": {"score": value},
+        "directions": {"score": direction},
+    }
+
+
+def _score(rows, baseline_values, scoring_cfg=None, series="v1.0"):
+    """Run the composite over rows, returning {device: metriq_score}."""
+    scoring_cfg = scoring_cfg or _scoring_cfg()
+    row_series = {id(r): series for r in rows}
+    baseline_avg = {
+        series: {
+            (BENCH, "score", _selector_fingerprint(sel)): val
+            for sel, val in zip(SELECTORS, baseline_values)
+        }
+    }
+    out = compute_device_composite_scores(rows, row_series, baseline_avg, scoring_cfg)
+    return {rec["device"]: rec for rec in out}
+
+
+class WidthAggregationTests(unittest.TestCase):
+    def test_near_zero_baseline_width_does_not_dominate(self):
+        """A width whose baseline sits at the noise floor must not swamp the group.
+
+        Mirrors the real ibm_torino/ibm_boston case: the baseline scored 0.0037 at
+        w=64, so normalizing that width on its own yields a 7192% ratio that, under
+        per-width normalization, supplied over half the device's composite.
+        """
+        rows = [
+            _row("dev", SELECTORS[0], 0.7477),
+            _row("dev", SELECTORS[1], 0.2661),
+        ]
+        recs = _score(rows, [0.3172, 0.0037])
+
+        # Width-aggregated: (1/9 * 0.7477 + 8/9 * 0.2661) / (1/9 * 0.3172 + 8/9 * 0.0037)
+        expected = 100.0 * (
+            (0.7477 / 9 + 8 * 0.2661 / 9) / (0.3172 / 9 + 8 * 0.0037 / 9)
+        )
+        self.assertAlmostEqual(recs["dev"]["metriq_score"], expected, places=6)
+
+        # Per-width normalization would have averaged 235.7% and 7191.9%, landing
+        # an order of magnitude higher.
+        per_width = (100.0 * 0.7477 / 0.3172) / 9 + 8 * (100.0 * 0.2661 / 0.0037) / 9
+        self.assertLess(recs["dev"]["metriq_score"], per_width / 5)
+
+    def test_group_subscore_is_shared_by_every_width(self):
+        rows = [
+            _row("dev", SELECTORS[0], 0.7477),
+            _row("dev", SELECTORS[1], 0.2661),
+        ]
+        rec = _score(rows, [0.3172, 0.0037])["dev"]
+        subscores = {c["group_subscore"] for c in rec["components"].values()}
+        self.assertEqual(len(subscores), 1)
+        # The group carries the full composite weight here, so the shared subscore
+        # is the device's score.
+        self.assertAlmostEqual(subscores.pop(), rec["metriq_score"], places=6)
+
+    def test_baseline_device_scores_exactly_100(self):
+        rows = [
+            _row("base_device", SELECTORS[0], 0.3172),
+            _row("base_device", SELECTORS[1], 0.0037),
+        ]
+        recs = _score(rows, [0.3172, 0.0037])
+        self.assertAlmostEqual(recs["base_device"]["metriq_score"], 100.0, places=9)
+
+    def test_baseline_device_anchors_even_when_a_width_measured_zero(self):
+        """A measured 0.0 is a result, not a missing submission.
+
+        The baseline cannot normalize its own zero, but the width is still present,
+        so it must not draw a coverage penalty.
+        """
+        rows = [
+            _row("base_device", SELECTORS[0], 0.3172),
+            _row("base_device", SELECTORS[1], 0.0),
+        ]
+        recs = _score(rows, [0.3172, 0.0])
+        self.assertAlmostEqual(recs["base_device"]["metriq_score"], 100.0, places=9)
+
+    def test_missing_width_is_penalized_by_its_sub_weight(self):
+        rows = [_row("dev", SELECTORS[0], 0.3172)]
+        recs = _score(rows, [0.3172, 0.0037])
+        # Parity on the only submitted width, which carries 1/9 of the group.
+        self.assertAlmostEqual(recs["dev"]["metriq_score"], 100.0 / 9, places=6)
+
+    def test_lower_is_better_inverts_the_aggregate_ratio(self):
+        rows = [
+            _row("dev", SELECTORS[0], 0.002, direction="lower"),
+            _row("dev", SELECTORS[1], 0.007, direction="lower"),
+        ]
+        recs = _score(rows, [0.005, 0.068])
+        expected = 100.0 * (
+            (0.005 / 9 + 8 * 0.068 / 9) / (0.002 / 9 + 8 * 0.007 / 9)
+        )
+        self.assertAlmostEqual(recs["dev"]["metriq_score"], expected, places=6)
+
+    def test_falls_back_to_normalized_scores_when_raw_values_are_absent(self):
+        """Derived metrics such as BSEQ carry no raw value to aggregate."""
+        rows = [
+            {
+                "provider": "ibm",
+                "device": "dev",
+                "timestamp": "2026-01-01T00:00:00",
+                "job_type": BENCH,
+                "params": dict(SELECTORS[0]),
+                "normalized_scores": {"score": 150.0},
+            },
+            {
+                "provider": "ibm",
+                "device": "dev",
+                "timestamp": "2026-01-01T00:00:00",
+                "job_type": BENCH,
+                "params": dict(SELECTORS[1]),
+                "normalized_scores": {"score": 300.0},
+            },
+        ]
+        recs = _score(rows, [0.3172, 0.0037])
+        self.assertAlmostEqual(
+            recs["dev"]["metriq_score"], 150.0 / 9 + 8 * 300.0 / 9, places=6
+        )
+
+    def test_harmonic_groups_are_unchanged(self):
+        rows = [
+            _row("dev", SELECTORS[0], 0.002, direction="lower"),
+            _row("dev", SELECTORS[1], 0.007, direction="lower"),
+        ]
+        recs = _score(rows, [0.005, 0.068], scoring_cfg=_scoring_cfg(aggregation="harmonic"))
+        # Weighted harmonic mean of the per-width normalized values.
+        n1 = 100.0 * 0.005 / 0.002
+        n2 = 100.0 * 0.068 / 0.007
+        expected = 1.0 / ((1.0 / 9) / n1 + (8.0 / 9) / n2)
+        self.assertAlmostEqual(recs["dev"]["metriq_score"], expected, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the composite-score inflation in #522, where ibm_boston reads 520.65 on metriq.info.

## The change

`compute_device_composite_scores` normalized each width-component against the baseline and then took a weighted mean of the ratios. The paper (arXiv:2603.08680, Section III) specifies the other order: Eq. (3) sums raw measurements across widths, Eqs. (4)/(5) normalize that aggregate once at the benchmark level, and Eq. (8) combines benchmarks. The paper is explicit that the aggregation belongs on the raw values because Eq. (3) is linear.

The two orders agree only when every width has a similar ratio. ibm_torino scored 0.0037 on `Mirror Circuits (w=64,d=4)`, which is the noise floor, so ibm_boston's 0.2661 normalized to 7192% and supplied 55.4% of its composite while carrying 4.0% of the weight. Width-aggregated, that benchmark contributes a 626% subscore instead.

Effect on the current dataset, both columns generated from the same input files:

| device | before | after |
|---|---|---|
| ibm_boston | 520.65 | 299.91 |
| ibm_kingston | 273.49 | 140.33 |
| H2-2 | 190.18 | 129.58 |
| ibm_pittsburgh | 176.71 | 178.00 |
| ibm_marrakesh | 129.78 | 115.28 |
| ibm_fez | 113.15 | 100.07 |
| ibm_torino | 89.06 | 97.07 |
| iqm_garnet | 49.86 | 49.95 |
| ibm_miami | 35.73 | 35.83 |
| ibm_brisbane | 13.94 | 14.06 |
| iqm_emerald | 11.97 | 12.66 |
| rigetti_cepheus-1-108q | 6.21 | 6.21 |
| ionq_forte-1 | 1.86 | 1.85 |
| wukong_72 | 1.84 | 1.85 |
| wukong_102 | 0.87 | 0.87 |
| rigetti_ankaa-3 | 0.66 | 0.66 |

Devices whose components are mostly single-width barely move, which is the expected shape: for a one-component group the two orders are identical.

## The baseline device

ibm_torino moving from 89.06 to 97.07 is the second defect the same change fixes. It has a real 0.0 measurement for `Mirror Circuits (w=128,d=2)`. Since it cannot normalize its own zero, `base > 0` failed and the width was counted as a missing submission and charged a coverage penalty. A measured zero is a result, not a gap. The baseline now anchors each component against its own raw value, so its subscores come out at exactly 100 and the residual 2.93 is the QFT weight, the one benchmark it has no usable result for.

## Compatibility

- Groups with nothing to aggregate, such as the derived BSEQ score which carries no raw value, fall back to the previous per-component path.
- Harmonic groups (EPLG) are untouched. The harmonic mean is dominated by its smallest term, so it does not show the blow-up. Its deviation from Eq. (5) is raised in #522 for a separate decision.
- Per-component `normalized` values are still emitted for the UI. Components in an aggregated group additionally carry `group_subscore`, the benchmark-level value that actually enters the composite, since the per-width ratios no longer explain the total on their own. Existing keys are unchanged.

## What this does not fix

Ratio-to-baseline is still unbounded when the baseline is at the floor. Width-aggregated, ibm_boston is at 626% on Mirror Circuits and 877% on EPLG. Capping, flooring the denominator, or reseating the baseline are policy calls, so they are left to #522 rather than decided here.

## Tests

`tests/test_composite_width_aggregation.py` covers the near-zero-baseline case with the real ibm_torino/ibm_boston numbers, the baseline anchoring at exactly 100 including when a width measured zero, the sub-weight penalty for a genuinely missing width, lower-is-better inversion at the aggregate level, the no-raw-values fallback, and that harmonic groups are unaffected. Four of them fail against the pre-fix code.