### PR TITLE
Publish score dispatch metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ Example `scripts/scoring.json`:
     "v0.4": {
       "baseline": { "provider": "origin", "device": "wukong_102" },
       "composite": {
+        "dispatch": { "suite": "metriq_score_1_0" },
         "components": [
           {
             "label": "BSEQ",
             "weight": "1/2",
+            "dispatch": { "component": "bseq" },
             "components": [
               { "benchmark": "BSEQ", "metric": "fraction_connected", "weight": "1/1" }
             ]
@@ -105,6 +107,7 @@ Example `scripts/scoring.json`:
           {
             "label": "QML Kernel",
             "weight": "1/2",
+            "dispatch": { "component": "qml-kernel" },
             "components": [
               { "benchmark": "QML Kernel", "metric": "accuracy_score", "selector": { "num_qubits": 10 }, "weight": "1/1" }
             ]
@@ -116,10 +119,12 @@ Example `scripts/scoring.json`:
   "default": {
     "baseline": { "provider": "ibm", "device": "ibm_torino" },
     "composite": {
+      "dispatch": { "suite": "metriq_score_1_0" },
       "components": [
         {
           "label": "BSEQ",
           "weight": "1/2",
+          "dispatch": { "component": "bseq" },
           "components": [
             { "benchmark": "BSEQ", "metric": "fraction_connected", "weight": "1/1" }
           ]
@@ -127,6 +132,7 @@ Example `scripts/scoring.json`:
         {
           "label": "QML Kernel",
           "weight": "1/2",
+          "dispatch": { "component": "qml-kernel" },
           "components": [
             { "benchmark": "QML Kernel", "metric": "accuracy_score", "selector": { "num_qubits": 10 }, "weight": "1/1" }
           ]
@@ -136,6 +142,12 @@ Example `scripts/scoring.json`:
   }
 }
 ```
+
+Optional `dispatch` metadata connects score components to the corresponding
+`metriq-gym` CLI selectors. The composite-level `suite` and group-level `component`
+are resolved into a complete `{ "suite": ..., "component": ... }` object on every
+generated leaf in `metriq_score.components`. Configurations that omit dispatch
+metadata retain the previous output shape.
 
 Baselines are computed per major series (e.g., all `v0.x.y` share one baseline reference),
 using the latest available baseline row per `(benchmark, metric, selector)` key.

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -138,6 +138,17 @@ def _derived_from_components(comp: dict[str, Any]) -> list[dict[str, Any]]:
     return [x for x in items if isinstance(x, dict)]
 
 
+def _dispatch_metadata(value: Any) -> dict[str, str]:
+    """Return normalized dispatch fields from a scoring config object."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: raw.strip()
+        for key in ("suite", "component")
+        if isinstance((raw := value.get(key)), str) and raw.strip()
+    }
+
+
 def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Flatten grouped composite components.
 
@@ -147,6 +158,7 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
 
     Returns leaf component dicts augmented with:
       - _group_label, _group_weight, _sub_weight, _effective_weight
+      - _dispatch, inherited from the group and overridden by the leaf
     """
     flat: list[dict[str, Any]] = []
     for comp in components:
@@ -156,6 +168,7 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
         if isinstance(group_children, list):
             group_label = comp.get("label") or comp.get("benchmark") or "group"
             group_weight = _parse_weight(comp.get("weight", 0.0))
+            group_dispatch = _dispatch_metadata(comp.get("dispatch"))
             for child in group_children:
                 if not isinstance(child, dict):
                     continue
@@ -165,6 +178,12 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
                 merged["_group_weight"] = group_weight
                 merged["_sub_weight"] = sub_weight
                 merged["_effective_weight"] = group_weight * sub_weight
+                resolved_dispatch = {
+                    **group_dispatch,
+                    **_dispatch_metadata(child.get("dispatch")),
+                }
+                if resolved_dispatch:
+                    merged["_dispatch"] = resolved_dispatch
                 flat.append(merged)
             continue
 
@@ -174,6 +193,9 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
         merged["_group_weight"] = 1.0
         merged["_sub_weight"] = sub_weight
         merged["_effective_weight"] = sub_weight
+        resolved_dispatch = _dispatch_metadata(comp.get("dispatch"))
+        if resolved_dispatch:
+            merged["_dispatch"] = resolved_dispatch
         flat.append(merged)
 
     return flat
@@ -620,13 +642,19 @@ def load_scoring_config(root: str) -> dict[str, Any]:
         "series": {
           "vX.Y": {
             "baseline": { "provider": str, "device": str },
-            "composite": { "components": [ ... ] }
+            "composite": {
+              "dispatch": { "suite": str },
+              "components": [ ... ]
+            }
           },
           ...
         },
         "default": {
           "baseline": { "provider": str, "device": str },
-          "composite": { "components": [ ... ] }
+          "composite": {
+            "dispatch": { "suite": str },
+            "components": [ ... ]
+          }
         }
       }
     """
@@ -643,11 +671,38 @@ def load_scoring_config(root: str) -> dict[str, Any]:
     return {}
 
 
-def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> None:
+def _validated_dispatch_metadata(value: Any, ctx: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid dispatch metadata in {ctx}: expected object")
+
+    normalized: dict[str, str] = {}
+    for key in ("suite", "component"):
+        if key not in value:
+            continue
+        raw = value.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            raise ValueError(f"Invalid dispatch {key} in {ctx}: expected non-empty string")
+        normalized[key] = raw.strip()
+    return normalized
+
+
+def _validate_components_list(
+    components: list[dict[str, Any]],
+    ctx: str,
+    inherited_dispatch: dict[str, str] | None = None,
+) -> None:
     total = 0.0
+    inherited_dispatch = inherited_dispatch or {}
     for i, comp in enumerate(components):
         if not isinstance(comp, dict):
             raise ValueError(f"Invalid component at index {i} in {ctx}: expected object")
+        comp_ctx = f"{ctx}.components[{i}]"
+        local_dispatch = (
+            _validated_dispatch_metadata(comp.get("dispatch"), f"{comp_ctx}.dispatch")
+            if "dispatch" in comp
+            else {}
+        )
+        resolved_dispatch = {**inherited_dispatch, **local_dispatch}
         children = comp.get("components")
         w_raw = comp.get("weight")
         try:
@@ -658,13 +713,37 @@ def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> Non
             raise ValueError(f"Negative weight for component {i} in {ctx}: {w_raw}")
 
         if isinstance(children, list):
-            _validate_components_list(children, ctx=f"{ctx}.components[{i}]")
+            _validate_components_list(
+                children,
+                ctx=comp_ctx,
+                inherited_dispatch=resolved_dispatch,
+            )
+        elif bool(resolved_dispatch.get("suite")) != bool(resolved_dispatch.get("component")):
+            raise ValueError(
+                f"Incomplete dispatch metadata in {comp_ctx}: "
+                "resolved leaf requires both suite and component"
+            )
         total += w
 
     if components:
         # Weight lists are expected to represent convex combinations.
         if abs(total - 1.0) > 1e-9:
             raise ValueError(f"Component weights must sum to 1.0 in {ctx}: got {total}")
+
+
+def _validate_composite_config(composite: dict[str, Any], ctx: str) -> None:
+    inherited_dispatch = (
+        _validated_dispatch_metadata(composite.get("dispatch"), f"{ctx}.dispatch")
+        if "dispatch" in composite
+        else {}
+    )
+    components = composite.get("components")
+    if isinstance(components, list):
+        _validate_components_list(
+            components,
+            ctx=ctx,
+            inherited_dispatch=inherited_dispatch,
+        )
 
 
 def validate_scoring_config(scoring_cfg: dict[str, Any]) -> None:
@@ -679,8 +758,8 @@ def validate_scoring_config(scoring_cfg: dict[str, Any]) -> None:
     default = scoring_cfg.get("default")
     if isinstance(default, dict):
         comp = default.get("composite")
-        if isinstance(comp, dict) and isinstance(comp.get("components"), list):
-            _validate_components_list(comp["components"], ctx="default.composite")
+        if isinstance(comp, dict):
+            _validate_composite_config(comp, ctx="default.composite")
 
     series_map = scoring_cfg.get("series")
     if isinstance(series_map, dict):
@@ -688,8 +767,8 @@ def validate_scoring_config(scoring_cfg: dict[str, Any]) -> None:
             if not isinstance(block, dict):
                 continue
             comp = block.get("composite")
-            if isinstance(comp, dict) and isinstance(comp.get("components"), list):
-                _validate_components_list(comp["components"], ctx=f"series.{label}.composite")
+            if isinstance(comp, dict):
+                _validate_composite_config(comp, ctx=f"series.{label}.composite")
 
 
 def _row_param_matches(selector: dict[str, Any] | None, row: dict[str, Any]) -> bool:
@@ -827,6 +906,7 @@ def compute_device_composite_scores(
         if not isinstance(components_cfg, list) or not components_cfg:
             # No components configured; skip this device
             continue
+        composite_dispatch = _dispatch_metadata(composite_cfg.get("dispatch"))
         components_flat = _flatten_components([c for c in components_cfg if isinstance(c, dict)])
         breakdown: dict[str, dict[str, Any]] = {}
         numerator = 0.0
@@ -922,7 +1002,7 @@ def compute_device_composite_scores(
             if normalized_value is not None:
                 numerator += weight * normalized_value
 
-            breakdown[label] = {
+            breakdown_entry = {
                 "metric": metric,
                 "weight": weight,
                 "group": group_label,
@@ -938,6 +1018,20 @@ def compute_device_composite_scores(
                 "raw_available": raw_value is not None,
                 "raw_timestamp": raw_ts,
             }
+            resolved_dispatch = {
+                **composite_dispatch,
+                **(
+                    comp.get("_dispatch")
+                    if isinstance(comp.get("_dispatch"), dict)
+                    else {}
+                ),
+            }
+            if resolved_dispatch.get("suite") and resolved_dispatch.get("component"):
+                breakdown_entry["dispatch"] = {
+                    "suite": resolved_dispatch["suite"],
+                    "component": resolved_dispatch["component"],
+                }
+            breakdown[label] = breakdown_entry
 
             # Surface a structural qubit requirement when the component selects a
             # fixed qubit count. This lets the UI tell a benchmark a device cannot

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -6,10 +6,12 @@
         "device": "ibm_torino"
       },
       "composite": {
+        "dispatch": { "suite": "metriq_score_1_0" },
         "components": [
           {
             "label": "BSEQ",
             "weight": "1/7",
+            "dispatch": { "component": "bseq" },
             "components": [
               {
                 "benchmark": "BSEQ",
@@ -25,6 +27,7 @@
           {
             "label": "QML Kernel",
             "weight": "1/7",
+            "dispatch": { "component": "qml-kernel" },
             "components": [
               {
                 "benchmark": "QML Kernel",
@@ -59,6 +62,7 @@
           {
             "label": "Mirror Circuits",
             "weight": "1/7",
+            "dispatch": { "component": "mirror-circuits" },
             "components": [
               {
                 "benchmark": "Mirror Circuits",
@@ -107,6 +111,7 @@
           {
             "label": "WIT",
             "weight": "1/7",
+            "dispatch": { "component": "wit" },
             "components": [
               {
                 "benchmark": "WIT",
@@ -120,6 +125,7 @@
           {
             "label": "Quantum Fourier Transform",
             "weight": "1/7",
+            "dispatch": { "component": "qft" },
             "components": [
               {
                 "benchmark": "Quantum Fourier Transform",
@@ -132,6 +138,7 @@
           {
             "label": "Linear Ramp QAOA",
             "weight": "1/7",
+            "dispatch": { "component": "lr-qaoa" },
             "components": [
               {
                 "benchmark": "Linear Ramp QAOA",
@@ -166,6 +173,7 @@
           {
             "label": "EPLG",
             "weight": "1/7",
+            "dispatch": { "component": "eplg" },
             "components": [
               {
                 "benchmark": "EPLG",
@@ -196,6 +204,7 @@
           {
             "label": "CLOPS",
             "weight": "0/1",
+            "dispatch": { "component": "clops" },
             "components": [
               {
                 "benchmark": "CLOPS",
@@ -216,10 +225,12 @@
       "device": "ibm_torino"
     },
     "composite": {
+      "dispatch": { "suite": "metriq_score_1_0" },
       "components": [
         {
           "label": "BSEQ",
           "weight": "1/8",
+          "dispatch": { "component": "bseq" },
           "components": [
             {
               "benchmark": "BSEQ",
@@ -235,6 +246,7 @@
         {
           "label": "QML Kernel",
           "weight": "1/8",
+          "dispatch": { "component": "qml-kernel" },
           "components": [
             {
               "benchmark": "QML Kernel",
@@ -269,6 +281,7 @@
         {
           "label": "Mirror Circuits",
           "weight": "1/8",
+          "dispatch": { "component": "mirror-circuits" },
           "components": [
             {
               "benchmark": "Mirror Circuits",
@@ -317,6 +330,7 @@
         {
           "label": "WIT",
           "weight": "1/8",
+          "dispatch": { "component": "wit" },
           "components": [
             {
               "benchmark": "WIT",
@@ -330,6 +344,7 @@
         {
           "label": "Quantum Fourier Transform",
           "weight": "1/8",
+          "dispatch": { "component": "qft" },
           "components": [
             {
               "benchmark": "Quantum Fourier Transform",
@@ -342,6 +357,7 @@
         {
           "label": "Linear Ramp QAOA",
           "weight": "1/8",
+          "dispatch": { "component": "lr-qaoa" },
           "components": [
             {
               "benchmark": "Linear Ramp QAOA",
@@ -376,6 +392,7 @@
         {
           "label": "EPLG",
           "weight": "1/8",
+          "dispatch": { "component": "eplg" },
           "components": [
             {
               "benchmark": "EPLG",
@@ -406,6 +423,7 @@
         {
           "label": "CLOPS",
           "weight": "1/8",
+          "dispatch": { "component": "clops" },
           "components": [
             {
               "benchmark": "CLOPS",

--- a/tests/test_scoring_dispatch.py
+++ b/tests/test_scoring_dispatch.py
@@ -1,0 +1,191 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+REPO_ROOT = SCRIPTS_DIR.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from etl import upsert_platform, write_platform_outputs  # noqa: E402
+from score import (  # noqa: E402
+    _flatten_components,
+    compute_device_composite_scores,
+    load_scoring_config,
+    validate_scoring_config,
+)
+
+
+def scoring_config(*, suite="future_score_2_0", component="future-component"):
+    composite = {
+        "components": [
+            {
+                "label": "Future component",
+                "weight": "1/1",
+                "components": [
+                    {
+                        "benchmark": "Future benchmark",
+                        "metric": "score",
+                        "label": "Future-10",
+                        "selector": {"num_qubits": 10},
+                        "weight": "1/2",
+                    },
+                    {
+                        "benchmark": "Future benchmark",
+                        "metric": "score",
+                        "label": "Future-20",
+                        "selector": {"num_qubits": 20},
+                        "weight": "1/2",
+                    },
+                ],
+            }
+        ]
+    }
+    if suite is not None:
+        composite["dispatch"] = {"suite": suite}
+    if component is not None:
+        composite["components"][0]["dispatch"] = {"component": component}
+    return {"default": {"composite": composite}}
+
+
+def composite_record(config, series="v0.7"):
+    row = {
+        "provider": "ibm",
+        "device": "ibm_future",
+        "timestamp": "2026-08-13T12:00:00Z",
+        "benchmark": "Unrelated benchmark",
+        "results": {},
+    }
+    return compute_device_composite_scores(
+        [row],
+        {id(row): series},
+        {},
+        config,
+    )[0]
+
+
+class ScoringDispatchTests(unittest.TestCase):
+    def test_dispatch_metadata_is_published_for_every_leaf_including_missing_results(self):
+        config = scoring_config()
+        validate_scoring_config(config)
+
+        record = composite_record(config)
+
+        self.assertEqual(record["series"], "v0.7")
+        self.assertEqual(set(record["components"]), {"Future-10", "Future-20"})
+        for component in record["components"].values():
+            self.assertFalse(component["raw_available"])
+            self.assertFalse(component["normalized_available"])
+            self.assertEqual(
+                component["dispatch"],
+                {"suite": "future_score_2_0", "component": "future-component"},
+            )
+
+    def test_config_without_dispatch_metadata_keeps_the_previous_output_shape(self):
+        config = scoring_config(suite=None, component=None)
+        validate_scoring_config(config)
+
+        record = composite_record(config)
+
+        for component in record["components"].values():
+            self.assertNotIn("dispatch", component)
+
+    def test_series_specific_composite_can_select_a_different_suite_version(self):
+        config = scoring_config(suite="future_score_2_0", component="future-component")
+        historical = scoring_config(
+            suite="historical_score_1_0",
+            component="historical-component",
+        )["default"]
+        config["series"] = {"v0.4": historical}
+        validate_scoring_config(config)
+
+        historical_record = composite_record(config, series="v0.4")
+        current_record = composite_record(config, series="v0.7")
+
+        self.assertEqual(
+            historical_record["components"]["Future-10"]["dispatch"],
+            {"suite": "historical_score_1_0", "component": "historical-component"},
+        )
+        self.assertEqual(
+            current_record["components"]["Future-10"]["dispatch"],
+            {"suite": "future_score_2_0", "component": "future-component"},
+        )
+
+    def test_validation_rejects_incomplete_or_malformed_dispatch_metadata(self):
+        cases = []
+
+        suite_only = scoring_config(component=None)
+        cases.append(suite_only)
+
+        component_only = scoring_config(suite=None)
+        cases.append(component_only)
+
+        empty_suite = scoring_config(suite="   ")
+        cases.append(empty_suite)
+
+        non_string_component = scoring_config()
+        non_string_component["default"]["composite"]["components"][0]["dispatch"] = {
+            "component": 42
+        }
+        cases.append(non_string_component)
+
+        non_object = scoring_config()
+        non_object["default"]["composite"]["dispatch"] = "future_score_2_0"
+        cases.append(non_object)
+
+        for config in cases:
+            with self.subTest(config=config):
+                with self.assertRaises(ValueError):
+                    validate_scoring_config(config)
+
+    def test_checked_in_series_resolve_complete_dispatch_pairs(self):
+        config = load_scoring_config(str(REPO_ROOT))
+        validate_scoring_config(config)
+
+        composites = [
+            config["series"]["v0.4"]["composite"],
+            config["default"]["composite"],
+        ]
+        for composite in composites:
+            suite = composite["dispatch"]["suite"]
+            flat = _flatten_components(composite["components"])
+            self.assertTrue(flat)
+            for leaf in flat:
+                self.assertEqual(suite, "metriq_score_1_0")
+                self.assertIsInstance(leaf["_dispatch"]["component"], str)
+                self.assertTrue(leaf["_dispatch"]["component"])
+
+    def test_platform_output_preserves_dispatch_metadata(self):
+        config = scoring_config()
+        record = composite_record(config)
+        source_row = {
+            "timestamp": "2026-08-13T12:00:00Z",
+            "platform": {"provider": "ibm", "device": "ibm_future"},
+            "results": {},
+        }
+        registry = {}
+        upsert_platform(registry, source_row, "result.json", "v0.7")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            write_platform_outputs(
+                registry,
+                tmp,
+                "2026-08-13T12:30:00Z",
+                composite_records=[record],
+            )
+            payload = json.loads(
+                (Path(tmp) / "platforms" / "ibm" / "ibm_future.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(
+            payload["metriq_score"]["components"]["Future-10"]["dispatch"],
+            {"suite": "future_score_2_0", "component": "future-component"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add declarative Metriq-Gym suite and component selectors to the existing scoring configuration.
- Resolve and publish a complete `dispatch: { suite, component }` pair on every generated score component, including components with no historical submission.
- Validate non-empty, complete dispatch metadata while preserving the previous output shape for configurations that omit it.
- Document the configuration contract and cover historical/current suite selection, validation, and platform-output propagation.

## Compatibility and rollout

This is an additive payload change. Existing consumers ignore the new field, while unitaryfoundation/metriq-web#36 consumes it instead of maintaining suite/component mappings in the browser.

This PR should be merged and the GitHub Pages data artifact deployed before unitaryfoundation/metriq-web#36 is merged.

## Testing

- `python3.13 -m unittest discover -s tests -v` — 11 tests passing
- `python3.13 scripts/aggregate.py`
- Audited the regenerated current platform set: zero score rows are missing a complete dispatch pair.