### PR TITLE
Add pull request previews for metriq-data

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -2,17 +2,48 @@ name: Aggregate metriq-data (PR)
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
     paths:
       - '*/v*/**/*.json'
       - '*/v*/**/*.json.gz'
       - 'scripts/**'
       - 'pages/**'
+      - 'tests/**'
+      - '.github/workflows/aggregate.yml'
+      - '.github/workflows/data-preview-deploy.yml'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: data-preview-build-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   aggregate:
     runs-on: ubuntu-latest
     steps:
+      - name: Write preview metadata
+        if: github.event_name == 'pull_request'
+        env:
+          PR_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREVIEW_SHA: ${{ github.sha }}
+        run: |
+          mkdir -p preview-metadata
+          printf '%s\n' "$PR_NUMBER" > preview-metadata/pr-number.txt
+          printf '%s\n' "$PR_ACTION" > preview-metadata/pr-action.txt
+          printf '%s\n' "$PREVIEW_SHA" > preview-metadata/preview-sha.txt
+
+      - name: Upload preview metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-preview-metadata
+          path: preview-metadata/
+          retention-days: 3
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -21,17 +52,19 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: Run unit tests
+        run: python -m unittest discover -s tests
+
       - name: Run ETL
-        run: |
-          python scripts/aggregate.py
+        run: python scripts/aggregate.py
 
       - name: Add static index.html
-        run: |
-          cp pages/index.html dist/index.html
+        run: cp pages/index.html dist/index.html
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
         with:
           name: aggregated-dist
           path: dist
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/data-preview-cleanup.yml
+++ b/.github/workflows/data-preview-cleanup.yml
@@ -1,0 +1,34 @@
+name: Cleanup metriq-data preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: data-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write preview metadata
+        env:
+          PR_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p preview-metadata
+          printf '%s\n' "$PR_NUMBER" > preview-metadata/pr-number.txt
+          printf '%s\n' "$PR_ACTION" > preview-metadata/pr-action.txt
+          printf '%s\n' "$PREVIEW_SHA" > preview-metadata/preview-sha.txt
+
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-preview-metadata
+          path: preview-metadata/
+          retention-days: 3

--- a/.github/workflows/data-preview-deploy.yml
+++ b/.github/workflows/data-preview-deploy.yml
@@ -17,8 +17,6 @@ permissions:
 
 concurrency:
   group: metriq-data-pages
-  # Preserve every serialized Pages mutation; queue: max is supported on GitHub.com:
-  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs
   queue: max
 
 jobs:

--- a/.github/workflows/data-preview-deploy.yml
+++ b/.github/workflows/data-preview-deploy.yml
@@ -17,6 +17,8 @@ permissions:
 
 concurrency:
   group: metriq-data-pages
+  # Preserve every serialized Pages mutation; queue: max is supported on GitHub.com:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs
   queue: max
 
 jobs:

--- a/.github/workflows/data-preview-deploy.yml
+++ b/.github/workflows/data-preview-deploy.yml
@@ -1,0 +1,244 @@
+name: Deploy metriq-data preview
+
+on:
+  workflow_run:
+    workflows:
+      - Aggregate metriq-data (PR)
+      - Cleanup metriq-data preview
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pages: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: metriq-data-pages
+  queue: max
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.pages-deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted deployment workflow
+        uses: actions/checkout@v5
+
+      - name: Download preview metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name data-preview-metadata \
+            --dir preview-metadata
+
+      - name: Read and validate preview metadata
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr_number="$(cat preview-metadata/pr-number.txt)"
+          pr_action="$(cat preview-metadata/pr-action.txt)"
+          preview_sha="$(cat preview-metadata/preview-sha.txt)"
+
+          case "$pr_number" in
+            ''|*[!0-9]*)
+              echo "Invalid PR number in preview metadata: $pr_number" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$pr_action" in
+            opened|reopened|synchronize|closed)
+              ;;
+            *)
+              echo "Invalid PR action in preview metadata: $pr_action" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$preview_sha" in
+            *[!0-9a-f]*|'')
+              echo "Invalid preview SHA in metadata: $preview_sha" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#preview_sha}" -ne 40 ]; then
+            echo "Invalid preview SHA length in metadata: $preview_sha" >&2
+            exit 1
+          fi
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"
+          pr_head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
+          pr_merge_sha="$(jq -r '.merge_commit_sha // empty' <<< "$pr_json")"
+          pr_state="$(jq -r '.state' <<< "$pr_json")"
+
+          if [ "$pr_head_sha" != "$RUN_HEAD_SHA" ] && [ "$pr_merge_sha" != "$RUN_HEAD_SHA" ]; then
+            echo "Preview metadata does not match the workflow run head SHA." >&2
+            echo "PR head SHA: $pr_head_sha" >&2
+            echo "PR merge SHA: $pr_merge_sha" >&2
+            echo "Run head SHA: $RUN_HEAD_SHA" >&2
+            exit 1
+          fi
+          if [ "$pr_state" = "open" ] && [ "$pr_action" != "closed" ] && [ "$pr_merge_sha" != "$preview_sha" ]; then
+            echo "Preview artifact is not the pull request's current merge revision." >&2
+            echo "PR merge SHA: $pr_merge_sha" >&2
+            echo "Preview SHA: $preview_sha" >&2
+            exit 1
+          fi
+
+          if [ "$pr_state" = "closed" ]; then
+            operation="remove"
+          elif [ "$pr_state" = "open" ] && [ "$pr_action" = "closed" ]; then
+            operation="none"
+          elif [ "$pr_state" = "open" ]; then
+            operation="deploy"
+          else
+            echo "Unexpected PR state: $pr_state" >&2
+            exit 1
+          fi
+
+          {
+            echo "pr_number=$pr_number"
+            echo "pr_action=$pr_action"
+            echo "operation=$operation"
+            echo "preview_sha=$preview_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download generated data
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name aggregated-dist \
+            --dir preview-data
+
+      - name: Validate deployable preview files
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        run: |
+          set -euo pipefail
+
+          find preview-data -type l -delete
+          find preview-data -type f ! -name '*.json' -delete
+          test -s preview-data/benchmark.latest.json
+          test -s preview-data/platforms/index.json
+
+          json_count="$(find preview-data -type f -name '*.json' | wc -l)"
+          entry_count="$(find preview-data -mindepth 1 | wc -l)"
+          total_bytes="$(du -sb preview-data | cut -f1)"
+          if [ "$json_count" -gt 1000 ] || [ "$entry_count" -gt 2000 ] || [ "$total_bytes" -gt 20971520 ]; then
+            echo "Preview artifact is unexpectedly large: $json_count JSON files, $entry_count entries, $total_bytes bytes" >&2
+            exit 1
+          fi
+
+          while IFS= read -r -d '' json_file; do
+            jq empty "$json_file"
+          done < <(find preview-data -type f -name '*.json' -print0)
+
+      - name: Checkout deployed production website
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        uses: actions/checkout@v5
+        with:
+          repository: unitaryfoundation/metriq-web
+          ref: gh-pages
+          path: production-web
+          persist-credentials: false
+
+      - name: Set up trusted preview assembler
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Assemble isolated production-UI preview
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        env:
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+          PREVIEW_SHA: ${{ steps.metadata.outputs.preview_sha }}
+        run: |
+          python scripts/prepare_preview.py \
+            --web-dir production-web \
+            --data-dir preview-data \
+            --output-dir preview-site \
+            --pr-number "$PR_NUMBER" \
+            --workflow-sha "$PREVIEW_SHA"
+
+      - name: Deploy preview files
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: preview-site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+          pr-number: ${{ steps.metadata.outputs.pr_number }}
+          comment: false
+          wait-for-pages-deployment: false
+          deploy-commit-message: Deploy data preview for PR ${{ steps.metadata.outputs.pr_number }}
+
+      - name: Remove preview files
+        if: ${{ steps.metadata.outputs.operation == 'remove' }}
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove
+          pr-number: ${{ steps.metadata.outputs.pr_number }}
+          comment: false
+          wait-for-pages-deployment: false
+          remove-commit-message: Remove data preview for PR ${{ steps.metadata.outputs.pr_number }}
+
+      - name: Checkout assembled Pages site
+        if: ${{ steps.metadata.outputs.operation != 'none' }}
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: pages-site
+
+      - name: Setup Pages
+        if: ${{ steps.metadata.outputs.operation != 'none' }}
+        uses: actions/configure-pages@v5
+
+      - name: Upload assembled Pages site
+        if: ${{ steps.metadata.outputs.operation != 'none' }}
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages-site
+
+      - name: Publish assembled Pages site
+        if: ${{ steps.metadata.outputs.operation != 'none' }}
+        id: pages-deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Post preview link
+        if: ${{ steps.metadata.outputs.operation == 'deploy' }}
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          number: ${{ steps.metadata.outputs.pr_number }}
+          header: metriq-data-preview
+          message: |
+            ## Metriq data preview
+
+            [Open this PR's data in the production Metriq UI](https://unitaryfoundation.github.io/metriq-data/pr-preview/pr-${{ steps.metadata.outputs.pr_number }}/)
+
+            Built from merge revision `${{ steps.metadata.outputs.preview_sha }}`. The preview is isolated from `metriq.info` and does not change production data.
+
+      - name: Remove preview link
+        if: ${{ steps.metadata.outputs.operation == 'remove' }}
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          number: ${{ steps.metadata.outputs.pr_number }}
+          header: metriq-data-preview
+          delete: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,8 +19,6 @@ permissions:
 
 concurrency:
   group: metriq-data-pages
-  # Preserve every serialized Pages mutation; queue: max is supported on GitHub.com:
-  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs
   queue: max
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,8 @@ permissions:
 
 concurrency:
   group: metriq-data-pages
+  # Preserve every serialized Pages mutation; queue: max is supported on GitHub.com:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs
   queue: max
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,16 +8,18 @@ on:
       - '*/v*/**/*.json.gz'
       - 'scripts/**'
       - 'pages/**'
+      - '.github/workflows/pages.yml'
+      - '.github/workflows/data-preview-deploy.yml'
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: metriq-data-pages
+  queue: max
 
 jobs:
   build:
@@ -37,8 +39,22 @@ jobs:
           python scripts/aggregate.py
 
       - name: Add static index.html
-        run: |
-          cp pages/index.html dist/index.html
+        run: cp pages/index.html dist/index.html
+
+      - name: Sync production data to Pages state branch
+        uses: JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23 # v4.7.4
+        with:
+          branch: gh-pages
+          folder: dist
+          clean-exclude: pr-preview/
+          commit-message: Deploy production metriq-data
+          force: false
+
+      - name: Checkout assembled Pages site
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: pages-site
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -46,7 +62,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: dist
+          path: pages-site
 
   deploy:
     environment:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ python -m http.server --directory dist 8000
 
 Then open `http://localhost:8000/`.
 
+### Pull request previews
+
+Pull requests that change benchmark data, aggregation, or scoring publish their
+generated JSON under `https://unitaryfoundation.github.io/metriq-data/pr-preview/pr-<PR_NUMBER>/`.
+That URL serves a snapshot of the currently deployed production Metriq UI with
+the pull request's data selected and an explicit staging banner. The preview is
+rebuilt from GitHub's merge revision on every update and removed when the pull
+request closes.
+
+Preview builds run with read-only permissions. A separate trusted workflow
+validates the pull request metadata, publishes only allowlisted JSON paths, and
+combines them with the trusted production website bundle; pull request code
+never receives deployment credentials and never supplies preview HTML or
+JavaScript.
+
 ### Metriq-score
 `metriq-score` is computed per metric relative to a baseline device, honoring directionality:
   - higher-is-better: `score = (value / baseline) * 100`

--- a/scripts/prepare_preview.py
+++ b/scripts/prepare_preview.py
@@ -61,17 +61,46 @@ def is_allowed_data_directory(relative_path: Path) -> bool:
     )
 
 
+def _allows_outcome_error_angle_brackets(
+    relative_path: Path, field_path: tuple[str | None, ...]
+) -> bool:
+    parts = relative_path.parts
+    is_benchmark_file = parts == ("benchmark.latest.json",) or (
+        len(parts) == 2
+        and VERSION_DIR_RE.fullmatch(parts[0]) is not None
+        and parts[1] == "benchmark.latest.json"
+    )
+    return is_benchmark_file and field_path == (
+        None,
+        "outcome_detail",
+        "error_message",
+    )
+
+
 def validate_json_content(value: object, relative_path: Path) -> None:
-    pending = [(value, None)]
+    pending: list[tuple[object, str | None, tuple[str | None, ...]]] = [
+        (value, None, ())
+    ]
     while pending:
-        item, field_name = pending.pop()
+        item, field_name, field_path = pending.pop()
         if isinstance(item, dict):
-            pending.extend((key, None) for key in item)
-            pending.extend((child, key.lower()) for key, child in item.items())
+            pending.extend((key, None, ()) for key in item)
+            pending.extend(
+                (child, key.lower(), (*field_path, key))
+                for key, child in item.items()
+            )
         elif isinstance(item, list):
-            pending.extend((child, field_name) for child in item)
+            pending.extend(
+                (child, field_name, (*field_path, None)) for child in item
+            )
         elif isinstance(item, str):
-            if "<" in item or ">" in item or CONTROL_CHARACTER_RE.search(item):
+            has_angle_brackets = "<" in item or ">" in item
+            if (
+                has_angle_brackets
+                and not _allows_outcome_error_angle_brackets(
+                    relative_path, field_path
+                )
+            ) or CONTROL_CHARACTER_RE.search(item):
                 raise ValueError(f"unsafe string in preview JSON: {relative_path}")
             if UNSAFE_URI_RE.match(item):
                 raise ValueError(f"unsafe URI in preview JSON: {relative_path}")

--- a/scripts/prepare_preview.py
+++ b/scripts/prepare_preview.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Assemble an isolated data-PR preview from trusted production web assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+VERSION_DIR_RE = re.compile(r"v\d+(?:\.\d+)*")
+PATH_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+UNSAFE_URI_RE = re.compile(r"\s*(?:data|javascript|vbscript):", re.IGNORECASE)
+CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f]")
+HTTPS_URL_RE = re.compile(r"https://[^\s]+", re.IGNORECASE)
+
+
+def positive_integer(value: str) -> int:
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
+
+
+def is_allowed_data_path(relative_path: Path) -> bool:
+    parts = relative_path.parts
+    if parts == ("benchmark.latest.json",):
+        return True
+    if parts == ("platforms", "index.json"):
+        return True
+    if (
+        len(parts) == 3
+        and parts[0] == "platforms"
+        and PATH_SEGMENT_RE.fullmatch(parts[1]) is not None
+        and Path(parts[2]).suffix == ".json"
+        and PATH_SEGMENT_RE.fullmatch(Path(parts[2]).stem) is not None
+    ):
+        return True
+    return (
+        len(parts) == 2
+        and VERSION_DIR_RE.fullmatch(parts[0]) is not None
+        and parts[1] == "benchmark.latest.json"
+    )
+
+
+def is_allowed_data_directory(relative_path: Path) -> bool:
+    parts = relative_path.parts
+    if parts == ("platforms",):
+        return True
+    if len(parts) == 1 and VERSION_DIR_RE.fullmatch(parts[0]) is not None:
+        return True
+    return (
+        len(parts) == 2
+        and parts[0] == "platforms"
+        and PATH_SEGMENT_RE.fullmatch(parts[1]) is not None
+    )
+
+
+def validate_json_content(value: object, relative_path: Path) -> None:
+    pending = [(value, None)]
+    while pending:
+        item, field_name = pending.pop()
+        if isinstance(item, dict):
+            pending.extend((key, None) for key in item)
+            pending.extend((child, key.lower()) for key, child in item.items())
+        elif isinstance(item, list):
+            pending.extend((child, field_name) for child in item)
+        elif isinstance(item, str):
+            if "<" in item or ">" in item or CONTROL_CHARACTER_RE.search(item):
+                raise ValueError(f"unsafe string in preview JSON: {relative_path}")
+            if UNSAFE_URI_RE.match(item):
+                raise ValueError(f"unsafe URI in preview JSON: {relative_path}")
+            if field_name and field_name.endswith(("url", "uri")) and item:
+                if HTTPS_URL_RE.fullmatch(item) is None:
+                    raise ValueError(f"non-HTTPS URL in preview JSON: {relative_path}")
+        elif isinstance(item, float) and not math.isfinite(item):
+            raise ValueError(f"non-finite number in preview JSON: {relative_path}")
+
+
+def validate_data_tree(data_directory: Path) -> None:
+    required = (
+        data_directory / "benchmark.latest.json",
+        data_directory / "platforms" / "index.json",
+    )
+    for path in required:
+        if not path.is_file():
+            raise ValueError(f"missing required preview data file: {path}")
+
+    for path in data_directory.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"preview data must not contain symlinks: {path}")
+        relative_path = path.relative_to(data_directory)
+        if path.is_dir():
+            if not is_allowed_data_directory(relative_path):
+                raise ValueError(f"unexpected preview data directory: {relative_path}")
+            continue
+        if not path.is_file():
+            raise ValueError(f"unexpected preview data entry: {relative_path}")
+        if not is_allowed_data_path(relative_path):
+            raise ValueError(f"unexpected preview data path: {relative_path}")
+        try:
+            with path.open(encoding="utf-8") as stream:
+                value = json.load(stream)
+            validate_json_content(value, relative_path)
+        except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as error:
+            raise ValueError(f"invalid preview JSON: {relative_path}") from error
+
+
+def preview_banner(pr_number: int) -> str:
+    pull_request_url = (
+        f"https://github.com/unitaryfoundation/metriq-data/pull/{pr_number}"
+    )
+    return f"""
+    <div role="status" style="background:#e0f2fe;border-bottom:1px solid #7dd3fc;color:#0c4a6e;display:flex;flex-wrap:wrap;font:600 15px/1.5 system-ui,sans-serif;gap:8px 20px;justify-content:center;padding:12px 20px;text-align:center">
+      <span><strong>Staging preview:</strong> production UI with the merge result from <a href="{pull_request_url}" style="color:#075985" target="_blank" rel="noopener noreferrer">metriq-data PR #{pr_number}</a>. These scores are not live.</span>
+      <a href="https://metriq.info/" style="color:#075985">Open production data</a>
+    </div>
+    """.strip()
+
+
+def prepare_preview(
+    web_directory: Path,
+    data_directory: Path,
+    output_directory: Path,
+    pr_number: int,
+    workflow_sha: str,
+) -> None:
+    web_directory = web_directory.resolve()
+    data_directory = data_directory.resolve()
+    output_directory = output_directory.resolve()
+
+    if not web_directory.is_dir():
+        raise ValueError(f"production web directory does not exist: {web_directory}")
+    if not data_directory.is_dir():
+        raise ValueError(f"preview data directory does not exist: {data_directory}")
+    if output_directory.exists():
+        raise ValueError(f"preview output already exists: {output_directory}")
+    if pr_number <= 0:
+        raise ValueError("pull request number must be positive")
+    if SHA_RE.fullmatch(workflow_sha) is None:
+        raise ValueError("workflow SHA must be a 40-character lowercase hex digest")
+
+    validate_data_tree(data_directory)
+
+    shutil.copytree(
+        web_directory,
+        output_directory,
+        ignore=shutil.ignore_patterns(".git", "CNAME", "pr-preview"),
+    )
+    preview_data_directory = output_directory / "metriq-data"
+    shutil.copytree(data_directory, preview_data_directory)
+
+    config_path = output_directory / "data" / "config.json"
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("production web bundle has no valid data/config.json") from error
+    if not isinstance(config, dict):
+        raise ValueError("production web data/config.json must contain an object")
+    config.update(
+        {
+            "benchmarksUrl": "./metriq-data/benchmark.latest.json",
+            "platformsIndexUrl": "./metriq-data/platforms/index.json",
+        }
+    )
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    index_path = output_directory / "index.html"
+    try:
+        index_html = index_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise ValueError("production web bundle has no readable index.html") from error
+    if index_html.count("<head>") != 1 or index_html.count("<body>") != 1:
+        raise ValueError("production web index.html has an unsupported document structure")
+    index_html = index_html.replace(
+        "<head>",
+        '<head>\n    <meta name="robots" content="noindex, nofollow" />',
+        1,
+    )
+    index_html = index_html.replace("<body>", f"<body>\n    {preview_banner(pr_number)}", 1)
+    index_path.write_text(index_html, encoding="utf-8")
+
+    manifest = {
+        "pull_request": pr_number,
+        "workflow_sha": workflow_sha,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "web_source": "unitaryfoundation/metriq-web@gh-pages",
+    }
+    (preview_data_directory / "preview-manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--web-dir", type=Path, required=True)
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--pr-number", type=positive_integer, required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    args = parser.parse_args()
+    prepare_preview(
+        args.web_dir,
+        args.data_dir,
+        args.output_dir,
+        args.pr_number,
+        args.workflow_sha,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prepare_preview.py
+++ b/tests/test_prepare_preview.py
@@ -1,0 +1,155 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from prepare_preview import (  # noqa: E402
+    is_allowed_data_directory,
+    is_allowed_data_path,
+    prepare_preview,
+    validate_data_tree,
+)
+
+
+class PreparePreviewTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.web = self.root / "web"
+        self.data = self.root / "data"
+        self.output = self.root / "output"
+
+        (self.web / "data").mkdir(parents=True)
+        (self.web / "data" / "config.json").write_text(
+            json.dumps(
+                {
+                    "benchmarksUrl": "https://example.com/production.json",
+                    "platformsIndexUrl": "https://example.com/platforms.json",
+                    "hiddenProviders": ["local"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.web / "index.html").write_text(
+            "<!doctype html><html><head><title>Metriq</title></head><body><main>Site</main></body></html>",
+            encoding="utf-8",
+        )
+        (self.web / "main.js").write_text("console.log('production');\n", encoding="utf-8")
+        (self.web / "CNAME").write_text("metriq.info\n", encoding="utf-8")
+        (self.web / ".git").mkdir()
+        (self.web / ".git" / "config").write_text("ignored\n", encoding="utf-8")
+        (self.web / "pr-preview" / "pr-1").mkdir(parents=True)
+        (self.web / "pr-preview" / "pr-1" / "index.html").write_text(
+            "unrelated web preview\n", encoding="utf-8"
+        )
+
+        (self.data / "platforms" / "ibm").mkdir(parents=True)
+        (self.data / "v0.7").mkdir()
+        (self.data / "benchmark.latest.json").write_text("[]\n", encoding="utf-8")
+        (self.data / "platforms" / "index.json").write_text(
+            '{"platforms": []}\n', encoding="utf-8"
+        )
+        (self.data / "platforms" / "ibm" / "ibm_fez.json").write_text(
+            '{}\n', encoding="utf-8"
+        )
+        (self.data / "v0.7" / "benchmark.latest.json").write_text(
+            "[]\n", encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def test_assembles_production_ui_with_preview_data_and_notice(self):
+        prepare_preview(
+            self.web,
+            self.data,
+            self.output,
+            pr_number=514,
+            workflow_sha="a" * 40,
+        )
+
+        config = json.loads((self.output / "data" / "config.json").read_text())
+        self.assertEqual(config["benchmarksUrl"], "./metriq-data/benchmark.latest.json")
+        self.assertEqual(
+            config["platformsIndexUrl"], "./metriq-data/platforms/index.json"
+        )
+        self.assertEqual(config["hiddenProviders"], ["local"])
+
+        html = (self.output / "index.html").read_text()
+        self.assertIn("Staging preview:", html)
+        self.assertIn("metriq-data PR #514", html)
+        self.assertIn('name="robots" content="noindex, nofollow"', html)
+        self.assertTrue((self.output / "main.js").is_file())
+        self.assertTrue(
+            (self.output / "metriq-data" / "platforms" / "ibm" / "ibm_fez.json").is_file()
+        )
+        self.assertFalse((self.output / "CNAME").exists())
+        self.assertFalse((self.output / ".git").exists())
+        self.assertFalse((self.output / "pr-preview").exists())
+
+        manifest = json.loads(
+            (self.output / "metriq-data" / "preview-manifest.json").read_text()
+        )
+        self.assertEqual(manifest["pull_request"], 514)
+        self.assertEqual(manifest["workflow_sha"], "a" * 40)
+
+    def test_rejects_unexpected_json_paths(self):
+        (self.data / "attacker.json").write_text("{}\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unexpected preview data path"):
+            validate_data_tree(self.data)
+
+    def test_rejects_non_json_files_and_symlinks(self):
+        (self.data / "index.html").write_text("<script></script>", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unexpected preview data path"):
+            validate_data_tree(self.data)
+
+    def test_rejects_html_and_executable_urls_in_json_values(self):
+        detail = self.data / "platforms" / "ibm" / "ibm_fez.json"
+        for payload in (
+            {"first_seen": '<img src=x onerror="alert(1)">'},
+            {"lifecycle": {"source_url": "javascript:alert(1)"}},
+            {"lifecycle": {"source_url": "http://example.com/source"}},
+            {"label": "line\nbreak"},
+        ):
+            detail.write_text(json.dumps(payload), encoding="utf-8")
+            with self.subTest(payload=payload), self.assertRaisesRegex(
+                ValueError, "unsafe|non-HTTPS"
+            ):
+                validate_data_tree(self.data)
+
+    def test_rejects_unexpected_directories(self):
+        (self.data / "unpublished" / "nested").mkdir(parents=True)
+        with self.assertRaisesRegex(ValueError, "unexpected preview data directory"):
+            validate_data_tree(self.data)
+
+    def test_allowlist_covers_only_web_consumed_outputs(self):
+        for path in (
+            "benchmark.latest.json",
+            "v0.7/benchmark.latest.json",
+            "v1.2.3/benchmark.latest.json",
+            "platforms/index.json",
+            "platforms/ibm/ibm_fez.json",
+        ):
+            self.assertTrue(is_allowed_data_path(Path(path)), path)
+        for path in (
+            "preview-manifest.json",
+            "v0.7/other.json",
+            "platforms/index.html",
+            "platforms/ibm/nested/device.json",
+            "other/file.json",
+        ):
+            self.assertFalse(is_allowed_data_path(Path(path)), path)
+
+        for path in ("platforms", "platforms/ibm", "v0.7"):
+            self.assertTrue(is_allowed_data_directory(Path(path)), path)
+        for path in ("other", "platforms/ibm/nested", "v-next"):
+            self.assertFalse(is_allowed_data_directory(Path(path)), path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prepare_preview.py
+++ b/tests/test_prepare_preview.py
@@ -121,6 +121,7 @@ class PreparePreviewTests(unittest.TestCase):
         detail = self.data / "platforms" / "ibm" / "ibm_fez.json"
         for payload in (
             {"first_seen": '<img src=x onerror="alert(1)">'},
+            [{"outcome_detail": {"error_message": "expected <T>"}}],
             {"lifecycle": {"source_url": "javascript:alert(1)"}},
             {"lifecycle": {"source_url": "http://example.com/source"}},
             {"label": "line\nbreak"},
@@ -128,6 +129,55 @@ class PreparePreviewTests(unittest.TestCase):
             detail.write_text(json.dumps(payload), encoding="utf-8")
             with self.subTest(payload=payload), self.assertRaisesRegex(
                 ValueError, "unsafe|non-HTTPS"
+            ):
+                validate_data_tree(self.data)
+
+    def test_allows_angle_brackets_in_outcome_error_messages(self):
+        payload = [
+            {
+                "outcome": "error",
+                "outcome_detail": {
+                    "error_message": "expected Foo<Bar>, got Baz<Qux>"
+                },
+            }
+        ]
+        for path in (
+            self.data / "benchmark.latest.json",
+            self.data / "v0.7" / "benchmark.latest.json",
+        ):
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+        validate_data_tree(self.data)
+
+    def test_rejects_angle_brackets_outside_outcome_error_messages(self):
+        benchmark = self.data / "benchmark.latest.json"
+        for payload in (
+            [{"error_message": "expected <T>"}],
+            [{"outcome_detail": {"reason": "expected <T>"}}],
+            [
+                {
+                    "wrapper": {
+                        "outcome_detail": {"error_message": "expected <T>"}
+                    }
+                }
+            ],
+            [{"outcome_detail": {"error_message": ["expected <T>"]}}],
+        ):
+            benchmark.write_text(json.dumps(payload), encoding="utf-8")
+            with self.subTest(payload=payload), self.assertRaisesRegex(
+                ValueError, "unsafe string"
+            ):
+                validate_data_tree(self.data)
+
+    def test_keeps_other_validation_for_outcome_error_messages(self):
+        benchmark = self.data / "benchmark.latest.json"
+        for error_message in ("line\nbreak", "javascript:alert(1)"):
+            payload = [
+                {"outcome_detail": {"error_message": error_message}}
+            ]
+            benchmark.write_text(json.dumps(payload), encoding="utf-8")
+            with self.subTest(error_message=error_message), self.assertRaisesRegex(
+                ValueError, "unsafe"
             ):
                 validate_data_tree(self.data)
 

--- a/tests/test_prepare_preview.py
+++ b/tests/test_prepare_preview.py
@@ -103,9 +103,18 @@ class PreparePreviewTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unexpected preview data path"):
             validate_data_tree(self.data)
 
-    def test_rejects_non_json_files_and_symlinks(self):
+    def test_rejects_non_json_files(self):
         (self.data / "index.html").write_text("<script></script>", encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "unexpected preview data path"):
+            validate_data_tree(self.data)
+
+    def test_rejects_symlinks(self):
+        symlink = self.data / "platforms" / "ibm" / "linked.json"
+        try:
+            symlink.symlink_to(self.data / "benchmark.latest.json")
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"symlink creation is unavailable: {error}")
+        with self.assertRaisesRegex(ValueError, "must not contain symlinks"):
             validate_data_tree(self.data)
 
     def test_rejects_html_and_executable_urls_in_json_values(self):


### PR DESCRIPTION
## Summary

- build the pull request merge revision with read-only permissions
- publish each generated dataset with the currently deployed metriq-web UI under a stable per-PR Pages URL
- preserve active previews across production data deploys and remove them when pull requests close
- post the preview URL back to the pull request

## Security

- separate untrusted aggregation from the trusted workflow_run publisher
- publish only bounded, allowlisted, valid JSON from the pull request artifact
- reject HTML-bearing strings outside schema-scoped `outcome_detail.error_message`, executable URI schemes, non-HTTPS URL fields, symlinks, and unexpected paths
- copy trusted UI assets from the deployed metriq-web gh-pages branch instead of accepting pull request HTML or JavaScript
- validate the live pull request state and merge SHA before publishing

## Validation

- `python3.13 -m unittest discover -s tests` (24 branch tests; 31 on the current-main merge revision in CI)
- full local aggregation (376 rows across 20 platforms)
- isolated preview assembly against the metriq-web production bundle
- workflow YAML parsing and git diff checks
