### PR TITLE
Fix QFT score width selection

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -24,7 +24,6 @@ from etl import (
     write_benchmark_latest,
 )
 from score import (
-    apply_custom_metric_derivations,
     load_scoring_config,
     validate_scoring_config,
     compute_baseline_averages_by_series,
@@ -45,8 +44,6 @@ def main(argv: list[str] | None = None) -> int:
     total_files = len(files)
     flat_rows, row_series, registry = collect_flat_rows_and_registry(root, files)
     platform_catalog = load_platform_catalog(root)
-    apply_custom_metric_derivations(flat_rows)
-
     # Scoring configured only via scripts/scoring.json
     scoring_cfg = load_scoring_config(root)
     # Validate composite weight sums per series/default

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -337,8 +337,7 @@ def _matching_components_for_row(
     for comp in _components_for_series(scoring_cfg, series_label):
         if not _component_matches_benchmark(comp, bench):
             continue
-        selector = comp.get("selector") if isinstance(comp.get("selector"), dict) else None
-        if not _row_param_matches(selector, row):
+        if not _component_param_matches(comp, row):
             continue
         metric = comp.get("metric")
         if not isinstance(metric, str):
@@ -370,6 +369,7 @@ def _baseline_component_signature(comp: dict[str, Any]) -> str:
         "benchmark": comp.get("benchmark"),
         "aliases": comp.get("aliases"),
         "selector": selector,
+        "selector_alternatives": comp.get("selector_alternatives"),
         "metrics": _component_candidate_metrics(comp),
     }
     return canonical_json(sig_obj)
@@ -405,7 +405,7 @@ def _latest_baseline_values_for_components(
             bench = derive_benchmark_name(r)
             if not _component_matches_benchmark(comp, bench):
                 continue
-            if not _row_param_matches(selector, r):
+            if not _component_param_matches(comp, r):
                 continue
             results = r.get("results") if isinstance(r.get("results"), dict) else {}
             ts = parse_timestamp(r.get("timestamp", ""))
@@ -702,6 +702,24 @@ def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> Non
                     f"'aggregation' is only valid on group components (index {i} in {ctx})"
                 )
 
+        selector_alternatives = comp.get("selector_alternatives")
+        if selector_alternatives is not None:
+            if not isinstance(comp.get("selector"), dict) or not comp["selector"]:
+                raise ValueError(
+                    f"Selector alternatives require a non-empty primary selector "
+                    f"(index {i} in {ctx})"
+                )
+            if not isinstance(selector_alternatives, list) or not selector_alternatives:
+                raise ValueError(
+                    f"Invalid selector alternatives for component {i} in {ctx}: "
+                    "expected a non-empty list"
+                )
+            if any(not isinstance(item, dict) or not item for item in selector_alternatives):
+                raise ValueError(
+                    f"Invalid selector alternative for component {i} in {ctx}: "
+                    "expected non-empty objects"
+                )
+
         if isinstance(children, list):
             _validate_components_list(children, ctx=f"{ctx}.components[{i}]")
         total += w
@@ -745,6 +763,22 @@ def _row_param_matches(selector: dict[str, Any] | None, row: dict[str, Any]) -> 
         if params.get(k) != v:
             return False
     return True
+
+
+def _component_param_matches(comp: dict[str, Any], row: dict[str, Any]) -> bool:
+    """Match a row against a component's primary or alternative selectors."""
+    selector = comp.get("selector") if isinstance(comp.get("selector"), dict) else None
+    if _row_param_matches(selector, row):
+        return True
+    alternatives = comp.get("selector_alternatives")
+    if not isinstance(alternatives, list):
+        return False
+    return any(
+        _row_param_matches(alternative, row)
+        for alternative in alternatives
+        if isinstance(alternative, dict) and alternative
+    )
+
 
 def _get_normalized_metric_value(
     row: dict[str, Any],
@@ -992,7 +1026,7 @@ def compute_device_composite_scores(
                 # Match benchmark by any allowed name (if provided)
                 if allowed_names and derive_benchmark_name(r) not in allowed_names:
                     continue
-                if not _row_param_matches(selector, r):
+                if not _component_param_matches(comp, r):
                     continue
                 series_label = row_series.get(id(r))
                 if picked_major is not None:

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -187,6 +187,7 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
                 merged["_sub_weight"] = sub_weight
                 merged["_effective_weight"] = group_weight * sub_weight
                 merged["_group_aggregation"] = group_aggregation
+                merged["_group_aggregate_fallbacks"] = comp.get("aggregate_fallbacks")
                 flat.append(merged)
             continue
 
@@ -252,19 +253,87 @@ def _selector_fingerprint(selector: dict[str, Any] | None) -> str:
     return canonical_json(selector)
 
 
-def _components_for_series(scoring_cfg: dict[str, Any], series_label: str | None) -> list[dict[str, Any]]:
+def _composite_for_series(
+    scoring_cfg: dict[str, Any], series_label: str | None
+) -> dict[str, Any]:
     if not isinstance(scoring_cfg, dict):
-        return []
+        return {}
     default_block = scoring_cfg.get("default") if isinstance(scoring_cfg.get("default"), dict) else {}
     series_map = scoring_cfg.get("series") if isinstance(scoring_cfg.get("series"), dict) else {}
     series_block = series_map.get(series_label) if isinstance(series_map, dict) else None
     composite = series_block.get("composite") if isinstance(series_block, dict) else None
     if not isinstance(composite, dict):
         composite = default_block.get("composite") if isinstance(default_block, dict) else None
+    return composite if isinstance(composite, dict) else {}
+
+
+def _components_for_series(scoring_cfg: dict[str, Any], series_label: str | None) -> list[dict[str, Any]]:
+    composite = _composite_for_series(scoring_cfg, series_label)
     components = composite.get("components") if isinstance(composite, dict) else None
     if not isinstance(components, list):
         return []
     return _flatten_components([c for c in components if isinstance(c, dict)])
+
+
+def _aggregate_fallbacks_for_series(
+    scoring_cfg: dict[str, Any], series_label: str | None
+) -> list[dict[str, Any]]:
+    """Return group fallbacks for rows that already aggregate several children.
+
+    Each config entry matches one aggregate row, names the canonical child labels
+    it covers, and declares the selector-specific baseline values to aggregate in
+    the same way. Benchmark-specific compatibility stays in scoring.json.
+    """
+    composite = _composite_for_series(scoring_cfg, series_label)
+    groups = composite.get("components")
+    if not isinstance(groups, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    for group in groups:
+        if not isinstance(group, dict) or not isinstance(group.get("components"), list):
+            continue
+        fallbacks = group.get("aggregate_fallbacks")
+        if not isinstance(fallbacks, list):
+            continue
+        for fallback in fallbacks:
+            if not isinstance(fallback, dict):
+                continue
+            configured = dict(fallback)
+            configured["_aggregate_fallback"] = True
+            configured["_group_label"] = group.get("label")
+            out.append(configured)
+    return out
+
+
+def _aggregate_fallback_baseline_components_for_series(
+    scoring_cfg: dict[str, Any], series_label: str | None
+) -> list[dict[str, Any]]:
+    """Return hidden components needed to build configured aggregate baselines."""
+    out: list[dict[str, Any]] = []
+    for fallback in _aggregate_fallbacks_for_series(scoring_cfg, series_label):
+        baseline_components = fallback.get("baseline_components")
+        if not isinstance(baseline_components, list):
+            continue
+        for baseline_component in baseline_components:
+            if not isinstance(baseline_component, dict):
+                continue
+            component = dict(baseline_component)
+            component.pop("weight", None)
+            for key in ("benchmark", "aliases", "metric"):
+                if key not in component and key in fallback:
+                    component[key] = fallback[key]
+            out.append(component)
+    return out
+
+
+def _baseline_components_for_series(
+    scoring_cfg: dict[str, Any], series_label: str | None
+) -> list[dict[str, Any]]:
+    return [
+        *_components_for_series(scoring_cfg, series_label),
+        *_aggregate_fallback_baseline_components_for_series(scoring_cfg, series_label),
+    ]
 
 
 def _baseline_provider_device_for_series(
@@ -493,9 +562,9 @@ def compute_baseline_averages_by_series(
         major_series_labels = [s for s in series_list if _series_major(s) == major]
         components: list[dict[str, Any]] = []
         for s in major_series_labels:
-            components.extend(_components_for_series(baselines_cfg, s))
+            components.extend(_baseline_components_for_series(baselines_cfg, s))
         if not components:
-            components = _components_for_series(baselines_cfg, ref_series)
+            components = _baseline_components_for_series(baselines_cfg, ref_series)
         components = _dedupe_baseline_components(components)
         baseline_by_major[major] = _latest_baseline_values_for_components(selected, components)
 
@@ -525,7 +594,7 @@ def compute_baseline_averages_by_series(
             r for r in flat_rows
             if r.get("provider") == base_provider and r.get("device") == base_device and row_series.get(id(r)) == series
         ]
-        components = _components_for_series(baselines_cfg, series)
+        components = _baseline_components_for_series(baselines_cfg, series)
         components = _dedupe_baseline_components(components)
         baseline_avg_by_series[series] = _latest_baseline_values_for_components(selected, components)
         summary.append(_baseline_summary_line(series, base_provider, base_device))
@@ -551,6 +620,25 @@ def compute_and_attach_metriq_scores(
 
         matching_components = _matching_components_for_row(scoring_cfg, series, r)
         if not matching_components:
+            fallback_matches = [
+                fallback
+                for fallback in _aggregate_fallbacks_for_series(scoring_cfg, series)
+                if _component_matches_benchmark(fallback, bench)
+                and _component_param_matches(fallback, r)
+            ]
+            fallback_metrics: set[str] = set()
+            for fallback in fallback_matches:
+                metric = fallback.get("metric")
+                if not isinstance(metric, str):
+                    continue
+                if metric in fallback_metrics:
+                    raise ValueError(
+                        f"Ambiguous aggregate fallbacks for {bench!r} metric "
+                        f"{metric!r} in series {series!r}"
+                    )
+                fallback_metrics.add(metric)
+            matching_components = fallback_matches
+        if not matching_components:
             continue
         # For a given row, only compute normalized scores for metrics explicitly configured
         # by matching components (benchmark + selector).
@@ -575,11 +663,16 @@ def compute_and_attach_metriq_scores(
                     continue
                 if not (v == v):  # NaN
                     continue
-                base = baseline_avg.get((bench, metric, selector_fp))
-                if base is None:
-                    base = _fallback_baseline_average(
-                        series, bench, metric, selector_fp, baseline_avg_by_series
+                if comp.get("_aggregate_fallback") is True:
+                    base = _aggregate_fallback_baseline(
+                        comp, series, baseline_avg_by_series
                     )
+                else:
+                    base = baseline_avg.get((bench, metric, selector_fp))
+                    if base is None:
+                        base = _fallback_baseline_average(
+                            series, bench, metric, selector_fp, baseline_avg_by_series
+                        )
                 if base is None:
                     continue
                 direction = str(dir_map.get(metric, "higher")).lower()
@@ -676,6 +769,140 @@ def load_scoring_config(root: str) -> dict[str, Any]:
     return {}
 
 
+def _validate_selector_alternatives(
+    comp: dict[str, Any], *, index: int, ctx: str
+) -> None:
+    selector_alternatives = comp.get("selector_alternatives")
+    if selector_alternatives is None:
+        return
+    if not isinstance(comp.get("selector"), dict) or not comp["selector"]:
+        raise ValueError(
+            f"Selector alternatives require a non-empty primary selector "
+            f"(index {index} in {ctx})"
+        )
+    if not isinstance(selector_alternatives, list) or not selector_alternatives:
+        raise ValueError(
+            f"Invalid selector alternatives for component {index} in {ctx}: "
+            "expected a non-empty list"
+        )
+    if any(not isinstance(item, dict) or not item for item in selector_alternatives):
+        raise ValueError(
+            f"Invalid selector alternative for component {index} in {ctx}: "
+            "expected non-empty objects"
+        )
+
+
+def _validate_aggregate_fallbacks(
+    group: dict[str, Any], *, index: int, ctx: str
+) -> None:
+    fallbacks = group.get("aggregate_fallbacks")
+    if fallbacks is None:
+        return
+    children = group.get("components")
+    if not isinstance(children, list):
+        raise ValueError(
+            f"Aggregate fallbacks are only valid on group components "
+            f"(index {index} in {ctx})"
+        )
+    aggregation = str(group.get("aggregation", "arithmetic")).lower()
+    if aggregation != "arithmetic":
+        raise ValueError(
+            f"Aggregate fallbacks require arithmetic group aggregation "
+            f"(index {index} in {ctx})"
+        )
+    if not isinstance(fallbacks, list) or not fallbacks:
+        raise ValueError(
+            f"Invalid aggregate fallbacks for component {index} in {ctx}: "
+            "expected a non-empty list"
+        )
+
+    child_labels = {
+        child.get("label")
+        for child in children
+        if isinstance(child, dict) and isinstance(child.get("label"), str)
+    }
+    for fallback_index, fallback in enumerate(fallbacks):
+        fallback_ctx = f"{ctx}.components[{index}].aggregate_fallbacks[{fallback_index}]"
+        if not isinstance(fallback, dict):
+            raise ValueError(f"Invalid aggregate fallback in {fallback_ctx}: expected object")
+        for key in ("benchmark", "metric", "label"):
+            if not isinstance(fallback.get(key), str) or not fallback[key].strip():
+                raise ValueError(
+                    f"Invalid aggregate fallback in {fallback_ctx}: "
+                    f"expected non-empty {key}"
+                )
+        if not isinstance(fallback.get("selector"), dict) or not fallback["selector"]:
+            raise ValueError(
+                f"Invalid aggregate fallback in {fallback_ctx}: "
+                "expected a non-empty selector"
+            )
+        _validate_selector_alternatives(fallback, index=fallback_index, ctx=fallback_ctx)
+
+        covers = fallback.get("covers")
+        if (
+            not isinstance(covers, list)
+            or not covers
+            or any(not isinstance(label, str) or not label for label in covers)
+            or len(set(covers)) != len(covers)
+            or any(label not in child_labels for label in covers)
+        ):
+            raise ValueError(
+                f"Invalid covered components in {fallback_ctx}: "
+                "expected unique child labels"
+            )
+
+        baseline_components = fallback.get("baseline_components")
+        if not isinstance(baseline_components, list) or not baseline_components:
+            raise ValueError(
+                f"Invalid baseline components in {fallback_ctx}: "
+                "expected a non-empty list"
+            )
+        baseline_weight = 0.0
+        for baseline_index, baseline_component in enumerate(baseline_components):
+            baseline_ctx = f"{fallback_ctx}.baseline_components[{baseline_index}]"
+            if not isinstance(baseline_component, dict):
+                raise ValueError(
+                    f"Invalid baseline component in {baseline_ctx}: expected object"
+                )
+            if (
+                not isinstance(baseline_component.get("selector"), dict)
+                or not baseline_component["selector"]
+            ):
+                raise ValueError(
+                    f"Invalid baseline component in {baseline_ctx}: "
+                    "expected a non-empty selector"
+                )
+            _validate_selector_alternatives(
+                baseline_component, index=baseline_index, ctx=baseline_ctx
+            )
+            try:
+                weight = _parse_weight(baseline_component.get("weight"))
+            except Exception:
+                raise ValueError(
+                    f"Invalid baseline component weight in {baseline_ctx}: "
+                    f"{baseline_component.get('weight')!r}"
+                )
+            if weight < 0:
+                raise ValueError(
+                    f"Negative baseline component weight in {baseline_ctx}: "
+                    f"{baseline_component.get('weight')!r}"
+                )
+            baseline_weight += weight
+        if abs(baseline_weight - 1.0) > 1e-9:
+            raise ValueError(
+                f"Baseline component weights must sum to 1.0 in {fallback_ctx}: "
+                f"got {baseline_weight}"
+            )
+
+        required = fallback.get("required_num_qubits")
+        if required is not None and (
+            isinstance(required, bool) or not isinstance(required, int) or required <= 0
+        ):
+            raise ValueError(
+                f"Invalid required_num_qubits in {fallback_ctx}: {required!r}"
+            )
+
+
 def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> None:
     total = 0.0
     for i, comp in enumerate(components):
@@ -702,23 +929,8 @@ def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> Non
                     f"'aggregation' is only valid on group components (index {i} in {ctx})"
                 )
 
-        selector_alternatives = comp.get("selector_alternatives")
-        if selector_alternatives is not None:
-            if not isinstance(comp.get("selector"), dict) or not comp["selector"]:
-                raise ValueError(
-                    f"Selector alternatives require a non-empty primary selector "
-                    f"(index {i} in {ctx})"
-                )
-            if not isinstance(selector_alternatives, list) or not selector_alternatives:
-                raise ValueError(
-                    f"Invalid selector alternatives for component {i} in {ctx}: "
-                    "expected a non-empty list"
-                )
-            if any(not isinstance(item, dict) or not item for item in selector_alternatives):
-                raise ValueError(
-                    f"Invalid selector alternative for component {i} in {ctx}: "
-                    "expected non-empty objects"
-                )
+        _validate_selector_alternatives(comp, index=i, ctx=ctx)
+        _validate_aggregate_fallbacks(comp, index=i, ctx=ctx)
 
         if isinstance(children, list):
             _validate_components_list(children, ctx=f"{ctx}.components[{i}]")
@@ -913,6 +1125,164 @@ def _pick_latest_metric_row(
     return picked, picked_ts
 
 
+def _aggregate_fallback_baseline(
+    fallback: dict[str, Any],
+    series_label: str | None,
+    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
+) -> float | None:
+    """Build the like-for-like baseline declared for an aggregate fallback."""
+    fallback_benchmark = fallback.get("benchmark")
+    fallback_metric = fallback.get("metric")
+    baseline_components = fallback.get("baseline_components")
+    if (
+        not isinstance(fallback_benchmark, str)
+        or not isinstance(fallback_metric, str)
+        or not isinstance(baseline_components, list)
+    ):
+        return None
+
+    baseline_map = baseline_avg_by_series.get(series_label or "", {})
+    total = 0.0
+    total_weight = 0.0
+    for component in baseline_components:
+        if not isinstance(component, dict):
+            return None
+        benchmark = component.get("benchmark", fallback_benchmark)
+        metric = component.get("metric", fallback_metric)
+        selector = component.get("selector")
+        if (
+            not isinstance(benchmark, str)
+            or not isinstance(metric, str)
+            or not isinstance(selector, dict)
+            or not selector
+        ):
+            return None
+        try:
+            weight = _parse_weight(component.get("weight"))
+        except Exception:
+            return None
+        selector_fp = _selector_fingerprint(selector)
+        base = baseline_map.get((benchmark, metric, selector_fp))
+        if base is None:
+            base = _fallback_baseline_average(
+                series_label,
+                benchmark,
+                metric,
+                selector_fp,
+                baseline_avg_by_series,
+            )
+        if base is None:
+            return None
+        total += weight * base
+        total_weight += weight
+    if total_weight <= 0:
+        return None
+    return total / total_weight
+
+
+def _pick_group_aggregate_fallback(
+    group: dict[str, Any],
+    rows: list[dict[str, Any]],
+    row_series: dict[int, str],
+    row_major_by_id: dict[int, int | None],
+    picked_series: str | None,
+    picked_major: int | None,
+    scoring_cfg: dict[str, Any],
+    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
+) -> dict[str, Any] | None:
+    """Pick the widest configured aggregate representation, then its latest row."""
+    items = group.get("items")
+    fallbacks = group.get("aggregate_fallbacks")
+    if not isinstance(items, list) or not isinstance(fallbacks, list):
+        return None
+
+    total_sub = sum(
+        float(item.get("sub_weight", 0.0))
+        for item in items
+        if isinstance(item, dict) and float(item.get("sub_weight", 0.0)) > 0
+    )
+    item_weights = {
+        item.get("label"): float(item.get("sub_weight", 0.0))
+        for item in items
+        if isinstance(item, dict) and isinstance(item.get("label"), str)
+    }
+    if total_sub <= 0:
+        return None
+
+    best: dict[str, Any] | None = None
+    best_coverage = -1.0
+    best_timestamp: datetime | None = None
+    for fallback in fallbacks:
+        if not isinstance(fallback, dict):
+            continue
+        covers = fallback.get("covers")
+        if not isinstance(covers, list) or any(label not in item_weights for label in covers):
+            continue
+        covered_sub = sum(item_weights[label] for label in covers)
+        if covered_sub <= 0:
+            continue
+        baseline = _aggregate_fallback_baseline(
+            fallback, picked_series, baseline_avg_by_series
+        )
+        if baseline is None:
+            continue
+        metric = fallback.get("metric")
+        if not isinstance(metric, str):
+            continue
+
+        matches: list[dict[str, Any]] = []
+        for row in rows:
+            if not _component_matches_benchmark(fallback, derive_benchmark_name(row)):
+                continue
+            if not _component_param_matches(fallback, row):
+                continue
+            series_label = row_series.get(id(row))
+            if picked_major is not None:
+                if row_major_by_id.get(id(row)) != picked_major:
+                    continue
+            elif series_label != picked_series:
+                continue
+            raw = _get_raw_metric_value(row, metric)
+            if raw is None:
+                continue
+            direction = _metric_direction(row, metric)
+            normalized: float | None = None
+            if _is_baseline_row_for_series(scoring_cfg, series_label, row):
+                normalized = 100.0
+            elif direction == "lower":
+                if raw > 0:
+                    normalized = 100.0 * baseline / raw
+            elif baseline > 0:
+                normalized = 100.0 * raw / baseline
+            if normalized is None:
+                continue
+            candidate = dict(row)
+            candidate["_raw_val"] = raw
+            candidate["_normalized_val"] = normalized
+            matches.append(candidate)
+
+        picked, timestamp = _pick_latest_metric_row(matches, "_raw_val")
+        if picked is None or timestamp is None:
+            continue
+        coverage = covered_sub / total_sub
+        if (
+            best is None
+            or coverage > best_coverage
+            or (coverage == best_coverage and (best_timestamp is None or timestamp > best_timestamp))
+        ):
+            best = {
+                "config": fallback,
+                "timestamp": picked.get("timestamp"),
+                "raw": float(picked["_raw_val"]),
+                "normalized": float(picked["_normalized_val"]),
+                "coverage": coverage,
+                "covered_components": list(covers),
+            }
+            best_coverage = coverage
+            best_timestamp = timestamp
+    return best
+
+
 def compute_device_composite_scores(
     flat_rows: list[dict[str, Any]],
     row_series: dict[int, str],
@@ -1088,7 +1458,13 @@ def compute_device_composite_scores(
                 group["items"].append((sub_weight, normalized_value))
             elif group_label is not None:
                 group = arithmetic_groups.setdefault(
-                    group_label, {"group_weight": group_weight, "items": []}
+                    group_label,
+                    {
+                        "group_label": group_label,
+                        "group_weight": group_weight,
+                        "items": [],
+                        "aggregate_fallbacks": comp.get("_group_aggregate_fallbacks"),
+                    },
                 )
                 group["items"].append(
                     {
@@ -1159,6 +1535,59 @@ def compute_device_composite_scores(
         for group in arithmetic_groups.values():
             items = group["items"]
             total_sub = sum(it["sub_weight"] for it in items if it["sub_weight"] > 0)
+            canonical_available = any(
+                it["raw"] is not None or it["normalized"] is not None for it in items
+            )
+            if not canonical_available:
+                fallback = _pick_group_aggregate_fallback(
+                    group,
+                    rows,
+                    row_series,
+                    row_major_by_id,
+                    picked_series,
+                    picked_major,
+                    scoring_cfg,
+                    baseline_avg_by_series,
+                )
+                if fallback is not None:
+                    fallback_cfg = fallback["config"]
+                    coverage = float(fallback["coverage"])
+                    value = float(fallback["normalized"])
+                    group_weight = float(group["group_weight"])
+                    numerator += group_weight * coverage * value
+                    for covered_label in fallback["covered_components"]:
+                        breakdown.pop(covered_label, None)
+
+                    label = str(fallback_cfg["label"])
+                    selector = fallback_cfg.get("selector")
+                    required = fallback_cfg.get("required_num_qubits")
+                    if not isinstance(required, int) and isinstance(selector, dict):
+                        for key in ("num_qubits", "width"):
+                            if isinstance(selector.get(key), int):
+                                required = selector[key]
+                                break
+                    breakdown[label] = {
+                        "metric": fallback_cfg["metric"],
+                        "weight": group_weight * coverage,
+                        "group": group.get("group_label"),
+                        "group_weight": group_weight,
+                        "sub_weight": coverage,
+                        "aggregation": "arithmetic",
+                        "timestamp": fallback["timestamp"],
+                        "normalized": value,
+                        "normalized_available": True,
+                        "normalized_timestamp": fallback["timestamp"],
+                        "raw": fallback["raw"],
+                        "raw_available": True,
+                        "raw_timestamp": fallback["timestamp"],
+                        "group_subscore": value,
+                        "aggregate_fallback": True,
+                        "coverage": coverage,
+                        "covered_components": fallback["covered_components"],
+                    }
+                    if isinstance(required, int):
+                        breakdown[label]["required_num_qubits"] = required
+                    continue
             subscore = _benchmark_subscore(items) if total_sub > 0 else None
             if subscore is None:
                 # No width has both a device and a baseline raw value (for example

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 import json
 import os
-import sys
-from typing import Any
+from typing import Any, NamedTuple
 
 from etl import (
     canonical_device_name,
@@ -90,67 +89,6 @@ def _series_major(series_label: str | None) -> int | None:
     return parsed[0]
 
 
-def _fallback_baseline_average(
-    series_label: str | None,
-    bench: str,
-    metric: str,
-    selector_fp: str,
-    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
-) -> float | None:
-    """Fallback to same-major latest baseline, then latest earlier series baseline."""
-    cur = _parse_series_label(series_label)
-    if cur is None:
-        return None
-    cur_major = cur[0]
-    same_major_best_ver: tuple[int, ...] | None = None
-    same_major_best_val: float | None = None
-    best_ver: tuple[int, ...] | None = None
-    best_val: float | None = None
-    for s, avg_map in baseline_avg_by_series.items():
-        ver = _parse_series_label(s)
-        if ver is None:
-            continue
-        val = avg_map.get((bench, metric, selector_fp))
-        if val is None:
-            continue
-        if ver[0] == cur_major:
-            if same_major_best_ver is None or ver > same_major_best_ver:
-                same_major_best_ver = ver
-                same_major_best_val = val
-            continue
-        if ver >= cur:
-            continue
-        if best_ver is None or ver > best_ver:
-            best_ver = ver
-            best_val = val
-    if same_major_best_val is not None:
-        return same_major_best_val
-    return best_val
-
-
-def apply_custom_metric_derivations(rows: list[dict[str, Any]]) -> None:
-    """Mutate rows in-place to add derived metrics where we define how to aggregate components.
-
-    For benchmarks that report multiple raw components, we can define a scalar metric here
-    so downstream metriq-score calculation is well-defined.
-    """
-    for row in rows:
-        bench = derive_benchmark_name(row)
-        if bench == "BSEQ":
-            _apply_bseq_metric(row)
-
-
-def _apply_bseq_metric(row: dict[str, Any]) -> None:
-    """Legacy hook for BSEQ derived metrics.
-
-    BSEQ scoring is now configured via scripts/scoring.json using baseline-normalized
-    component metrics (e.g., largest_connected_size and fraction_connected). We keep
-    this function to avoid breaking the derivation pipeline, but do not emit a raw
-    `bseq_score` value here (since it depends on baseline normalization).
-    """
-    return
-
-
 def _derived_from_components(comp: dict[str, Any]) -> list[dict[str, Any]]:
     items = comp.get("derived_from")
     if not isinstance(items, list):
@@ -234,16 +172,28 @@ def _compute_derived_normalized_score(
     return numerator / denom
 
 
-def _component_matches_benchmark(comp: dict[str, Any], bench: str) -> bool:
-    bench_field = comp.get("benchmark")
-    if isinstance(bench_field, str) and bench_field == bench:
-        return True
-    if isinstance(bench_field, list) and any(isinstance(b, str) and b == bench for b in bench_field):
-        return True
+def _component_benchmarks(comp: dict[str, Any]) -> set[str]:
+    benchmark = comp.get("benchmark")
+    names = {benchmark} if isinstance(benchmark, str) else set()
+    if isinstance(benchmark, list):
+        names.update(name for name in benchmark if isinstance(name, str))
     aliases = comp.get("aliases")
-    if isinstance(aliases, list) and any(isinstance(a, str) and a == bench for a in aliases):
-        return True
-    return False
+    if isinstance(aliases, list):
+        names.update(alias for alias in aliases if isinstance(alias, str))
+    return names
+
+
+def _primary_benchmark(comp: dict[str, Any]) -> str | None:
+    benchmark = comp.get("benchmark")
+    if isinstance(benchmark, str):
+        return benchmark
+    if isinstance(benchmark, list):
+        return next((name for name in benchmark if isinstance(name, str)), None)
+    return None
+
+
+def _component_matches_benchmark(comp: dict[str, Any], bench: str) -> bool:
+    return bench in _component_benchmarks(comp)
 
 
 def _selector_fingerprint(selector: dict[str, Any] | None) -> str:
@@ -252,16 +202,24 @@ def _selector_fingerprint(selector: dict[str, Any] | None) -> str:
     return canonical_json(selector)
 
 
-def _components_for_series(scoring_cfg: dict[str, Any], series_label: str | None) -> list[dict[str, Any]]:
-    if not isinstance(scoring_cfg, dict):
-        return []
-    default_block = scoring_cfg.get("default") if isinstance(scoring_cfg.get("default"), dict) else {}
-    series_map = scoring_cfg.get("series") if isinstance(scoring_cfg.get("series"), dict) else {}
+def _series_setting(
+    scoring_cfg: dict[str, Any], series_label: str | None, name: str
+) -> dict[str, Any]:
+    """Return a series setting, falling back to the default block."""
+    series_map = scoring_cfg.get("series")
     series_block = series_map.get(series_label) if isinstance(series_map, dict) else None
-    composite = series_block.get("composite") if isinstance(series_block, dict) else None
-    if not isinstance(composite, dict):
-        composite = default_block.get("composite") if isinstance(default_block, dict) else None
-    components = composite.get("components") if isinstance(composite, dict) else None
+    value = series_block.get(name) if isinstance(series_block, dict) else None
+    if isinstance(value, dict):
+        return value
+    default = scoring_cfg.get("default")
+    value = default.get(name) if isinstance(default, dict) else None
+    return value if isinstance(value, dict) else {}
+
+
+def _components_for_series(
+    scoring_cfg: dict[str, Any], series_label: str | None
+) -> list[dict[str, Any]]:
+    components = _series_setting(scoring_cfg, series_label, "composite").get("components")
     if not isinstance(components, list):
         return []
     return _flatten_components([c for c in components if isinstance(c, dict)])
@@ -271,16 +229,7 @@ def _baseline_provider_device_for_series(
     scoring_cfg: dict[str, Any],
     series_label: str | None,
 ) -> tuple[str | None, str | None]:
-    if not isinstance(scoring_cfg, dict):
-        return None, None
-    default_block = scoring_cfg.get("default") if isinstance(scoring_cfg.get("default"), dict) else {}
-    series_map = scoring_cfg.get("series") if isinstance(scoring_cfg.get("series"), dict) else {}
-    series_block = series_map.get(series_label) if isinstance(series_map, dict) else None
-    baseline = series_block.get("baseline") if isinstance(series_block, dict) else None
-    if not isinstance(baseline, dict):
-        baseline = default_block.get("baseline") if isinstance(default_block, dict) else None
-    if not isinstance(baseline, dict):
-        return None, None
+    baseline = _series_setting(scoring_cfg, series_label, "baseline")
     provider = baseline.get("provider") if isinstance(baseline.get("provider"), str) else None
     device = baseline.get("device") if isinstance(baseline.get("device"), str) else None
     if provider is None or device is None:
@@ -328,19 +277,18 @@ def _is_baseline_row_for_series(
 
 
 def _matching_components_for_row(
-    scoring_cfg: dict[str, Any],
-    series_label: str | None,
+    components: list[dict[str, Any]],
     row: dict[str, Any],
 ) -> list[dict[str, Any]]:
     bench = derive_benchmark_name(row)
     out: list[dict[str, Any]] = []
-    for comp in _components_for_series(scoring_cfg, series_label):
+    for comp in components:
         if not _component_matches_benchmark(comp, bench):
             continue
         if not _component_param_matches(comp, row):
             continue
         metric = comp.get("metric")
-        if not isinstance(metric, str):
+        if not isinstance(metric, str) or not metric:
             continue
         out.append(comp)
     return out
@@ -360,32 +308,6 @@ def _component_candidate_metrics(comp: dict[str, Any]) -> list[str]:
             continue
         seen.add(part_metric)
         out.append(part_metric)
-    return out
-
-
-def _baseline_component_signature(comp: dict[str, Any]) -> str:
-    selector = comp.get("selector") if isinstance(comp.get("selector"), dict) else None
-    sig_obj = {
-        "benchmark": comp.get("benchmark"),
-        "aliases": comp.get("aliases"),
-        "selector": selector,
-        "selector_alternatives": comp.get("selector_alternatives"),
-        "metrics": _component_candidate_metrics(comp),
-    }
-    return canonical_json(sig_obj)
-
-
-def _dedupe_baseline_components(components: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for comp in components:
-        if not isinstance(comp, dict):
-            continue
-        sig = _baseline_component_signature(comp)
-        if sig in seen:
-            continue
-        seen.add(sig)
-        out.append(comp)
     return out
 
 
@@ -496,8 +418,14 @@ def compute_baseline_averages_by_series(
             components.extend(_components_for_series(baselines_cfg, s))
         if not components:
             components = _components_for_series(baselines_cfg, ref_series)
-        components = _dedupe_baseline_components(components)
         baseline_by_major[major] = _latest_baseline_values_for_components(selected, components)
+
+    # Carry missing baseline keys forward from earlier score majors. This is the
+    # same fallback policy normalization used to apply one lookup at a time.
+    inherited: dict[tuple[str, str, str], float] = {}
+    for major in sorted(baseline_by_major):
+        inherited = {**inherited, **baseline_by_major[major]}
+        baseline_by_major[major] = inherited
 
     for series in series_list:
         major = _series_major(series)
@@ -526,7 +454,6 @@ def compute_baseline_averages_by_series(
             if r.get("provider") == base_provider and r.get("device") == base_device and row_series.get(id(r)) == series
         ]
         components = _components_for_series(baselines_cfg, series)
-        components = _dedupe_baseline_components(components)
         baseline_avg_by_series[series] = _latest_baseline_values_for_components(selected, components)
         summary.append(_baseline_summary_line(series, base_provider, base_device))
 
@@ -539,60 +466,35 @@ def compute_and_attach_metriq_scores(
     baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
     scoring_cfg: dict[str, Any],
 ) -> None:
+    component_cache: dict[str | None, list[dict[str, Any]]] = {}
     for r in flat_rows:
         results = r.get("results") if isinstance(r.get("results"), dict) else {}
         if not results:
             continue
-        bench = derive_benchmark_name(r)
-        dir_map = r.get("directions") if isinstance(r.get("directions"), dict) else {}
         series = row_series.get(id(r))
-        baseline_avg = baseline_avg_by_series.get(series or "", {})
         scores: dict[str, float] = {}
 
-        matching_components = _matching_components_for_row(scoring_cfg, series, r)
+        if series not in component_cache:
+            component_cache[series] = _components_for_series(scoring_cfg, series)
+        matching_components = _matching_components_for_row(component_cache[series], r)
         if not matching_components:
             continue
         # For a given row, only compute normalized scores for metrics explicitly configured
         # by matching components (benchmark + selector).
-        metric_to_comp: dict[str, dict[str, Any]] = {}
-        for comp in matching_components:
-            metric = comp.get("metric")
-            if not isinstance(metric, str) or not metric:
-                continue
-            metric_to_comp[metric] = comp
-        target_metrics = list(metric_to_comp.keys())
+        metric_to_comp = {comp["metric"]: comp for comp in matching_components}
 
-        for metric in target_metrics:
-            comp = metric_to_comp.get(metric, {})
+        for metric, comp in metric_to_comp.items():
             selector = comp.get("selector") if isinstance(comp.get("selector"), dict) else None
             selector_fp = _selector_fingerprint(selector)
 
             if metric in results:
-                val = results.get(metric)
-                try:
-                    v = float(val)
-                except Exception:
-                    continue
-                if not (v == v):  # NaN
-                    continue
-                base = baseline_avg.get((bench, metric, selector_fp))
-                if base is None:
-                    base = _fallback_baseline_average(
-                        series, bench, metric, selector_fp, baseline_avg_by_series
-                    )
-                if base is None:
-                    continue
-                direction = str(dir_map.get(metric, "higher")).lower()
-                score: float | None = None
-                try:
-                    if direction == "lower":
-                        if v > 0:
-                            score = (base / v) * 100.0
-                    else:
-                        if base > 0:
-                            score = (v / base) * 100.0
-                except Exception:
-                    score = None
+                score = _normalized_ratio(
+                    results[metric],
+                    _get_baseline_metric_value(
+                        r, metric, series, selector_fp, baseline_avg_by_series
+                    ),
+                    _metric_direction(r, metric),
+                )
             else:
                 score = _compute_derived_normalized_score(
                     r,
@@ -624,14 +526,8 @@ def compute_and_attach_metriq_scores(
                 comp = metric_to_comp.get(metric, {})
                 if comp.get("_group_aggregation") == "harmonic":
                     harmonic = True
-                w_raw = comp.get("_effective_weight", comp.get("weight", 0.0))
-                try:
-                    weight = float(w_raw)
-                except Exception:
-                    weight = 0.0
-                if not (weight == weight) or weight in (float("inf"), float("-inf")) or weight < 0:
-                    weight = 0.0
-                if weight == 0.0:
+                weight = float(comp.get("_effective_weight", 0.0))
+                if weight <= 0.0:
                     continue
                 pairs.append((weight, metric_score))
             if harmonic:
@@ -646,34 +542,13 @@ def compute_and_attach_metriq_scores(
 
 
 def load_scoring_config(root: str) -> dict[str, Any]:
-    """Load scoring configuration (baselines + composite) from scripts/scoring.json.
-
-    Expected shape:
-      {
-        "series": {
-          "vX.Y": {
-            "baseline": { "provider": str, "device": str },
-            "composite": { "components": [ ... ] }
-          },
-          ...
-        },
-        "default": {
-          "baseline": { "provider": str, "device": str },
-          "composite": { "components": [ ... ] }
-        }
-      }
-    """
+    """Load the required scoring configuration."""
     scoring_path = os.path.join(root, "scripts", "scoring.json")
-    try:
-        with open(scoring_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            if isinstance(data, dict):
-                return data
-    except FileNotFoundError:
-        print("Error: scripts/scoring.json not found", file=sys.stderr)
-    except Exception as e:
-        print(f"Warning: failed to load scoring.json: {e}", file=sys.stderr)
-    return {}
+    with open(scoring_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("Invalid scoring config: expected object")
+    return data
 
 
 def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> None:
@@ -780,6 +655,22 @@ def _component_param_matches(comp: dict[str, Any], row: dict[str, Any]) -> bool:
     )
 
 
+def _normalized_ratio(value: Any, baseline: Any, direction: str) -> float | None:
+    """Normalize one raw value against its baseline."""
+    value_num = _coerce_float(value)
+    baseline_num = _coerce_float(baseline)
+    if value_num is None or baseline_num is None:
+        return None
+    if value_num in (float("inf"), float("-inf")) or baseline_num in (
+        float("inf"),
+        float("-inf"),
+    ):
+        return None
+    if direction == "lower":
+        return (baseline_num / value_num) * 100.0 if value_num > 0 else None
+    return (value_num / baseline_num) * 100.0 if baseline_num > 0 else None
+
+
 def _get_normalized_metric_value(
     row: dict[str, Any],
     metric: str,
@@ -790,40 +681,17 @@ def _get_normalized_metric_value(
     # Prefer precomputed normalized scores
     norm = row.get("normalized_scores")
     if isinstance(norm, dict) and metric in norm and norm[metric] is not None:
-        try:
-            return float(norm[metric])
-        except Exception:
-            pass
+        value = _coerce_float(norm[metric])
+        if value is not None:
+            return value
 
-    # Fallback: compute ad-hoc from row's raw result using baseline averages
-    results = row.get("results") if isinstance(row.get("results"), dict) else {}
-    if metric not in results:
-        return None
-    try:
-        v = float(results[metric])
-    except Exception:
-        return None
-    if not (v == v):  # NaN
-        return None
-    bench = derive_benchmark_name(row)
-    baseline_avg = baseline_avg_by_series.get(series_label or "", {})
-    base = baseline_avg.get((bench, metric, selector_fp))
-    if base is None:
-        base = _fallback_baseline_average(series_label, bench, metric, selector_fp, baseline_avg_by_series)
-    if base is None:
-        return None
-    dir_map = row.get("directions") if isinstance(row.get("directions"), dict) else {}
-    direction = str(dir_map.get(metric, "higher")).lower()
-    try:
-        if direction == "lower":
-            if v > 0:
-                return (base / v) * 100.0
-        else:
-            if base > 0:
-                return (v / base) * 100.0
-    except Exception:
-        return None
-    return None
+    return _normalized_ratio(
+        _get_raw_metric_value(row, metric),
+        _get_baseline_metric_value(
+            row, metric, series_label, selector_fp, baseline_avg_by_series
+        ),
+        _metric_direction(row, metric),
+    )
 
 
 def _get_baseline_metric_value(
@@ -841,12 +709,7 @@ def _get_baseline_metric_value(
     """
     bench = derive_benchmark_name(row)
     baseline_avg = baseline_avg_by_series.get(series_label or "", {})
-    base = baseline_avg.get((bench, metric, selector_fp))
-    if base is None:
-        base = _fallback_baseline_average(
-            series_label, bench, metric, selector_fp, baseline_avg_by_series
-        )
-    return base
+    return baseline_avg.get((bench, metric, selector_fp))
 
 
 def _metric_direction(row: dict[str, Any], metric: str) -> str:
@@ -894,23 +757,30 @@ def _get_raw_metric_value(row: dict[str, Any], metric: str) -> float | None:
     return _coerce_float(results.get(metric))
 
 
-def _pick_latest_metric_row(
-    candidates: list[dict[str, Any]],
-    value_key: str,
-) -> tuple[dict[str, Any] | None, datetime | None]:
-    """Pick the latest timestamped row containing value_key."""
-    picked = None
-    picked_ts = None
-    for cand in candidates:
-        if value_key not in cand:
-            continue
-        ts = parse_timestamp(cand.get("timestamp", ""))
-        if ts is None:
-            continue
-        if picked is None or picked_ts is None or ts > picked_ts:
-            picked = cand
-            picked_ts = ts
-    return picked, picked_ts
+class _TimestampedValue(NamedTuple):
+    timestamp: datetime
+    source_timestamp: Any
+    value: Any
+
+
+class _RawValue(NamedTuple):
+    raw: float
+    baseline: float | None
+    direction: str
+
+
+def _latest_timestamped_value(
+    current: _TimestampedValue | None,
+    row: dict[str, Any],
+    value: Any,
+) -> _TimestampedValue | None:
+    """Keep a value when its row is newer than the current selection."""
+    if value is None:
+        return current
+    timestamp = parse_timestamp(row.get("timestamp", ""))
+    if timestamp is None or (current is not None and timestamp <= current.timestamp):
+        return current
+    return _TimestampedValue(timestamp, row.get("timestamp"), value)
 
 
 def compute_device_composite_scores(
@@ -943,9 +813,7 @@ def compute_device_composite_scores(
 
     out: list[dict[str, Any]] = []
     row_major_by_id = {rid: _series_major(series_label) for rid, series_label in row_series.items()}
-    series_cfg_map = scoring_cfg.get("series", {}) if isinstance(scoring_cfg, dict) else {}
-    default_composite = ((scoring_cfg.get("default", {}) or {}).get("composite", {})
-                         if isinstance(scoring_cfg, dict) else {})
+    component_cache: dict[str | None, list[dict[str, Any]]] = {}
     for (provider, device), rows in grouped.items():
         # pick device's latest series by timestamp
         latest_ts = None
@@ -960,43 +828,21 @@ def compute_device_composite_scores(
                 picked_series = s
 
         picked_major = _series_major(picked_series)
-        series_block = (series_cfg_map.get(picked_series, {}) if isinstance(series_cfg_map, dict) else {})
-        composite_cfg = series_block.get("composite") or default_composite
-        components_cfg = composite_cfg.get("components") if isinstance(composite_cfg, dict) else None
-        if not isinstance(components_cfg, list) or not components_cfg:
+        if picked_series not in component_cache:
+            component_cache[picked_series] = _components_for_series(scoring_cfg, picked_series)
+        components_flat = component_cache[picked_series]
+        if not components_flat:
             # No components configured; skip this device
             continue
-        components_flat = _flatten_components([c for c in components_cfg if isinstance(c, dict)])
         breakdown: dict[str, dict[str, Any]] = {}
         numerator = 0.0
         sum_w_defined = 0.0
-        # Group label -> {"group_weight": float, "items": [(sub_weight, normalized_value | None)]}
-        # for groups aggregated with a harmonic mean instead of the default arithmetic sum.
-        harmonic_groups: dict[str, dict[str, Any]] = {}
-        # Group label -> {"group_weight": float, "items": [...], "labels": [...]} for groups
-        # aggregated over raw values across circuit widths before baseline normalization.
-        arithmetic_groups: dict[str, dict[str, Any]] = {}
-        # Components with no group (or no usable raw/baseline pair) fall back to the
-        # per-component normalized values.
+        groups: dict[tuple[Any, str], dict[str, Any]] = {}
         ungrouped: list[tuple[float, float]] = []
 
         for comp in components_flat:
-            if not isinstance(comp, dict):
-                continue
             bench_field = comp.get("benchmark")
-            # Allow a single name or a list of names, plus optional aliases
-            allowed_names: set[str] = set()
-            if isinstance(bench_field, str):
-                allowed_names.add(bench_field)
-            elif isinstance(bench_field, list):
-                for b in bench_field:
-                    if isinstance(b, str):
-                        allowed_names.add(b)
-            aliases = comp.get("aliases")
-            if isinstance(aliases, list):
-                for a in aliases:
-                    if isinstance(a, str):
-                        allowed_names.add(a)
+            allowed_names = _component_benchmarks(comp)
             metric = comp.get("metric")
             group_label = comp.get("_group_label")
             group_weight = float(comp.get("_group_weight", 1.0))
@@ -1004,26 +850,18 @@ def compute_device_composite_scores(
             weight = float(comp.get("_effective_weight", _parse_weight(comp.get("weight", 0.0))))
             selector = comp.get("selector") if isinstance(comp.get("selector"), dict) else None
             # Prefer the primary benchmark name for label when available
-            primary_bench: str | None = None
-            if isinstance(bench_field, str):
-                primary_bench = bench_field
-            elif isinstance(bench_field, list) and bench_field:
-                first = bench_field[0]
-                if isinstance(first, str):
-                    primary_bench = first
-
-            label = comp.get("label")
-            if not label:
-                label = f"{primary_bench}:{metric}" if primary_bench and metric else "component"
+            primary_bench = _primary_benchmark(comp)
+            label = comp.get("label") or (
+                f"{primary_bench}:{metric}" if primary_bench and metric else "component"
+            )
             # Always include every component's weight in the denominator; if a
             # component is missing for this device, its normalized contribution is 0.
             sum_w_defined += weight
 
-            # Filter rows by benchmark, selector, and major-version group.
-            # Keep candidates if either normalized or raw value is available.
-            matches: list[dict[str, Any]] = []
+            selector_fp = _selector_fingerprint(selector)
+            latest_normalized = None
+            latest_raw = None
             for r in rows:
-                # Match benchmark by any allowed name (if provided)
                 if allowed_names and derive_benchmark_name(r) not in allowed_names:
                     continue
                 if not _component_param_matches(comp, r):
@@ -1034,7 +872,6 @@ def compute_device_composite_scores(
                         continue
                 elif series_label != picked_series:
                     continue
-                selector_fp = _selector_fingerprint(selector)
                 normalized_val = _get_normalized_metric_value(
                     r, metric, series_label, selector_fp, baseline_avg_by_series
                 )
@@ -1042,14 +879,11 @@ def compute_device_composite_scores(
                 if normalized_val is not None and is_baseline_row:
                     # Keep baseline components anchored at 100 in platform composites.
                     normalized_val = 100.0
+                latest_normalized = _latest_timestamped_value(
+                    latest_normalized, r, normalized_val
+                )
                 raw_val = _get_raw_metric_value(r, metric)
-                if normalized_val is None and raw_val is None:
-                    continue
-                r_copy = dict(r)
-                if normalized_val is not None:
-                    r_copy["_normalized_val"] = float(normalized_val)
                 if raw_val is not None:
-                    r_copy["_raw_val"] = float(raw_val)
                     # Anchor the baseline device against its own value so its
                     # width-aggregated subscores come out at exactly 100.
                     base_val = (
@@ -1059,57 +893,41 @@ def compute_device_composite_scores(
                             r, metric, series_label, selector_fp, baseline_avg_by_series
                         )
                     )
-                    if base_val is not None:
-                        r_copy["_baseline_val"] = float(base_val)
-                    r_copy["_direction"] = _metric_direction(r, metric)
-                matches.append(r_copy)
+                    latest_raw = _latest_timestamped_value(
+                        latest_raw,
+                        r,
+                        _RawValue(raw_val, base_val, _metric_direction(r, metric)),
+                    )
 
-            picked_norm, _ = _pick_latest_metric_row(matches, "_normalized_val")
-            picked_raw, _ = _pick_latest_metric_row(matches, "_raw_val")
-
-            normalized_value = (
-                float(picked_norm.get("_normalized_val"))
-                if picked_norm is not None and picked_norm.get("_normalized_val") is not None
-                else None
+            normalized_ts = (
+                latest_normalized.source_timestamp if latest_normalized else None
             )
-            raw_value = (
-                float(picked_raw.get("_raw_val"))
-                if picked_raw is not None and picked_raw.get("_raw_val") is not None
-                else None
+            normalized_value = latest_normalized.value if latest_normalized else None
+            raw_ts = latest_raw.source_timestamp if latest_raw else None
+            raw_value, baseline_value, direction = (
+                latest_raw.value if latest_raw else (None, None, "higher")
             )
-            normalized_ts = picked_norm.get("timestamp") if picked_norm is not None else None
-            raw_ts = picked_raw.get("timestamp") if picked_raw is not None else None
 
             aggregation = comp.get("_group_aggregation", "arithmetic")
-            if aggregation == "harmonic" and group_label is not None:
-                group = harmonic_groups.setdefault(
-                    group_label, {"group_weight": group_weight, "items": []}
-                )
-                group["items"].append((sub_weight, normalized_value))
-            elif group_label is not None:
-                group = arithmetic_groups.setdefault(
-                    group_label, {"group_weight": group_weight, "items": []}
-                )
-                group["items"].append(
+            item = {
+                "label": label,
+                "sub_weight": sub_weight,
+                "weight": weight,
+                "normalized": normalized_value,
+                "raw": raw_value,
+                "baseline": baseline_value,
+                "direction": direction,
+            }
+            if group_label is not None:
+                group = groups.setdefault(
+                    (group_label, aggregation),
                     {
-                        "label": label,
-                        "sub_weight": sub_weight,
-                        "weight": weight,
-                        "normalized": normalized_value,
-                        "raw": raw_value,
-                        "baseline": (
-                            float(picked_raw.get("_baseline_val"))
-                            if picked_raw is not None
-                            and picked_raw.get("_baseline_val") is not None
-                            else None
-                        ),
-                        "direction": (
-                            str(picked_raw.get("_direction", "higher"))
-                            if picked_raw is not None
-                            else "higher"
-                        ),
-                    }
+                        "group_weight": group_weight,
+                        "aggregation": aggregation,
+                        "items": [],
+                    },
                 )
+                group["items"].append(item)
             elif normalized_value is not None:
                 ungrouped.append((weight, normalized_value))
 
@@ -1147,18 +965,31 @@ def compute_device_composite_scores(
             if isinstance(required, int):
                 breakdown[label]["required_num_qubits"] = required
 
-        for weight, normalized_value in ungrouped:
-            numerator += weight * normalized_value
+        for weight, value in ungrouped:
+            numerator += weight * value
 
-        # Fold arithmetic groups into the numerator. Following the Metriq Score
-        # definition (arXiv:2603.08680, Eqs. 3-5), the raw measurements are summed
-        # across circuit widths first and the aggregate is normalized against the
-        # baseline once, so a width whose baseline value sits at the noise floor
-        # cannot contribute an unbounded ratio. Missing widths still contribute 0
-        # through the present sub-weight share.
-        for group in arithmetic_groups.values():
+        # Fold each group into the composite. Arithmetic groups normalize the
+        # weighted raw aggregate once; harmonic groups combine normalized values.
+        # Preserve the previous arithmetic-before-harmonic addition order so the
+        # published floating-point scores stay byte-for-byte stable.
+        ordered_groups = sorted(
+            groups.values(), key=lambda group: group["aggregation"] == "harmonic"
+        )
+        for group in ordered_groups:
             items = group["items"]
             total_sub = sum(it["sub_weight"] for it in items if it["sub_weight"] > 0)
+            if group["aggregation"] == "harmonic":
+                present = [
+                    (it["sub_weight"], it["normalized"])
+                    for it in items
+                    if it["sub_weight"] > 0 and it["normalized"] is not None
+                ]
+                present_sub = sum(weight for weight, _value in present)
+                mean = _weighted_harmonic_mean(present)
+                if total_sub > 0 and mean is not None:
+                    numerator += group["group_weight"] * mean * (present_sub / total_sub)
+                continue
+
             subscore = _benchmark_subscore(items) if total_sub > 0 else None
             if subscore is None:
                 # No width has both a device and a baseline raw value (for example
@@ -1171,22 +1002,6 @@ def compute_device_composite_scores(
             numerator += float(group["group_weight"]) * value * (present_sub / total_sub)
             for it in items:
                 breakdown[it["label"]]["group_subscore"] = value
-
-        # Fold harmonic groups into the numerator: the group's score is the
-        # weighted harmonic mean of its available components, scaled by the
-        # share of sub-weight that is present so missing components still
-        # contribute 0 (mirroring the arithmetic path).
-        for group in harmonic_groups.values():
-            items = [(w, v) for w, v in group["items"] if w > 0]
-            total_sub = sum(w for w, _v in items)
-            present = [(w, v) for w, v in items if v is not None]
-            present_sub = sum(w for w, _v in present)
-            if total_sub <= 0 or not present:
-                continue
-            hm = _weighted_harmonic_mean(present)
-            if hm is None:
-                continue
-            numerator += float(group["group_weight"]) * hm * (present_sub / total_sub)
 
         # Denominator is the sum of all defined weights; missing components
         # contribute 0 to the numerator but still count in the denominator.

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -187,7 +187,6 @@ def _flatten_components(components: list[dict[str, Any]]) -> list[dict[str, Any]
                 merged["_sub_weight"] = sub_weight
                 merged["_effective_weight"] = group_weight * sub_weight
                 merged["_group_aggregation"] = group_aggregation
-                merged["_group_aggregate_fallbacks"] = comp.get("aggregate_fallbacks")
                 flat.append(merged)
             continue
 
@@ -253,87 +252,19 @@ def _selector_fingerprint(selector: dict[str, Any] | None) -> str:
     return canonical_json(selector)
 
 
-def _composite_for_series(
-    scoring_cfg: dict[str, Any], series_label: str | None
-) -> dict[str, Any]:
+def _components_for_series(scoring_cfg: dict[str, Any], series_label: str | None) -> list[dict[str, Any]]:
     if not isinstance(scoring_cfg, dict):
-        return {}
+        return []
     default_block = scoring_cfg.get("default") if isinstance(scoring_cfg.get("default"), dict) else {}
     series_map = scoring_cfg.get("series") if isinstance(scoring_cfg.get("series"), dict) else {}
     series_block = series_map.get(series_label) if isinstance(series_map, dict) else None
     composite = series_block.get("composite") if isinstance(series_block, dict) else None
     if not isinstance(composite, dict):
         composite = default_block.get("composite") if isinstance(default_block, dict) else None
-    return composite if isinstance(composite, dict) else {}
-
-
-def _components_for_series(scoring_cfg: dict[str, Any], series_label: str | None) -> list[dict[str, Any]]:
-    composite = _composite_for_series(scoring_cfg, series_label)
     components = composite.get("components") if isinstance(composite, dict) else None
     if not isinstance(components, list):
         return []
     return _flatten_components([c for c in components if isinstance(c, dict)])
-
-
-def _aggregate_fallbacks_for_series(
-    scoring_cfg: dict[str, Any], series_label: str | None
-) -> list[dict[str, Any]]:
-    """Return group fallbacks for rows that already aggregate several children.
-
-    Each config entry matches one aggregate row, names the canonical child labels
-    it covers, and declares the selector-specific baseline values to aggregate in
-    the same way. Benchmark-specific compatibility stays in scoring.json.
-    """
-    composite = _composite_for_series(scoring_cfg, series_label)
-    groups = composite.get("components")
-    if not isinstance(groups, list):
-        return []
-
-    out: list[dict[str, Any]] = []
-    for group in groups:
-        if not isinstance(group, dict) or not isinstance(group.get("components"), list):
-            continue
-        fallbacks = group.get("aggregate_fallbacks")
-        if not isinstance(fallbacks, list):
-            continue
-        for fallback in fallbacks:
-            if not isinstance(fallback, dict):
-                continue
-            configured = dict(fallback)
-            configured["_aggregate_fallback"] = True
-            configured["_group_label"] = group.get("label")
-            out.append(configured)
-    return out
-
-
-def _aggregate_fallback_baseline_components_for_series(
-    scoring_cfg: dict[str, Any], series_label: str | None
-) -> list[dict[str, Any]]:
-    """Return hidden components needed to build configured aggregate baselines."""
-    out: list[dict[str, Any]] = []
-    for fallback in _aggregate_fallbacks_for_series(scoring_cfg, series_label):
-        baseline_components = fallback.get("baseline_components")
-        if not isinstance(baseline_components, list):
-            continue
-        for baseline_component in baseline_components:
-            if not isinstance(baseline_component, dict):
-                continue
-            component = dict(baseline_component)
-            component.pop("weight", None)
-            for key in ("benchmark", "aliases", "metric"):
-                if key not in component and key in fallback:
-                    component[key] = fallback[key]
-            out.append(component)
-    return out
-
-
-def _baseline_components_for_series(
-    scoring_cfg: dict[str, Any], series_label: str | None
-) -> list[dict[str, Any]]:
-    return [
-        *_components_for_series(scoring_cfg, series_label),
-        *_aggregate_fallback_baseline_components_for_series(scoring_cfg, series_label),
-    ]
 
 
 def _baseline_provider_device_for_series(
@@ -562,9 +493,9 @@ def compute_baseline_averages_by_series(
         major_series_labels = [s for s in series_list if _series_major(s) == major]
         components: list[dict[str, Any]] = []
         for s in major_series_labels:
-            components.extend(_baseline_components_for_series(baselines_cfg, s))
+            components.extend(_components_for_series(baselines_cfg, s))
         if not components:
-            components = _baseline_components_for_series(baselines_cfg, ref_series)
+            components = _components_for_series(baselines_cfg, ref_series)
         components = _dedupe_baseline_components(components)
         baseline_by_major[major] = _latest_baseline_values_for_components(selected, components)
 
@@ -594,7 +525,7 @@ def compute_baseline_averages_by_series(
             r for r in flat_rows
             if r.get("provider") == base_provider and r.get("device") == base_device and row_series.get(id(r)) == series
         ]
-        components = _baseline_components_for_series(baselines_cfg, series)
+        components = _components_for_series(baselines_cfg, series)
         components = _dedupe_baseline_components(components)
         baseline_avg_by_series[series] = _latest_baseline_values_for_components(selected, components)
         summary.append(_baseline_summary_line(series, base_provider, base_device))
@@ -620,25 +551,6 @@ def compute_and_attach_metriq_scores(
 
         matching_components = _matching_components_for_row(scoring_cfg, series, r)
         if not matching_components:
-            fallback_matches = [
-                fallback
-                for fallback in _aggregate_fallbacks_for_series(scoring_cfg, series)
-                if _component_matches_benchmark(fallback, bench)
-                and _component_param_matches(fallback, r)
-            ]
-            fallback_metrics: set[str] = set()
-            for fallback in fallback_matches:
-                metric = fallback.get("metric")
-                if not isinstance(metric, str):
-                    continue
-                if metric in fallback_metrics:
-                    raise ValueError(
-                        f"Ambiguous aggregate fallbacks for {bench!r} metric "
-                        f"{metric!r} in series {series!r}"
-                    )
-                fallback_metrics.add(metric)
-            matching_components = fallback_matches
-        if not matching_components:
             continue
         # For a given row, only compute normalized scores for metrics explicitly configured
         # by matching components (benchmark + selector).
@@ -663,16 +575,11 @@ def compute_and_attach_metriq_scores(
                     continue
                 if not (v == v):  # NaN
                     continue
-                if comp.get("_aggregate_fallback") is True:
-                    base = _aggregate_fallback_baseline(
-                        comp, series, baseline_avg_by_series
+                base = baseline_avg.get((bench, metric, selector_fp))
+                if base is None:
+                    base = _fallback_baseline_average(
+                        series, bench, metric, selector_fp, baseline_avg_by_series
                     )
-                else:
-                    base = baseline_avg.get((bench, metric, selector_fp))
-                    if base is None:
-                        base = _fallback_baseline_average(
-                            series, bench, metric, selector_fp, baseline_avg_by_series
-                        )
                 if base is None:
                     continue
                 direction = str(dir_map.get(metric, "higher")).lower()
@@ -769,140 +676,6 @@ def load_scoring_config(root: str) -> dict[str, Any]:
     return {}
 
 
-def _validate_selector_alternatives(
-    comp: dict[str, Any], *, index: int, ctx: str
-) -> None:
-    selector_alternatives = comp.get("selector_alternatives")
-    if selector_alternatives is None:
-        return
-    if not isinstance(comp.get("selector"), dict) or not comp["selector"]:
-        raise ValueError(
-            f"Selector alternatives require a non-empty primary selector "
-            f"(index {index} in {ctx})"
-        )
-    if not isinstance(selector_alternatives, list) or not selector_alternatives:
-        raise ValueError(
-            f"Invalid selector alternatives for component {index} in {ctx}: "
-            "expected a non-empty list"
-        )
-    if any(not isinstance(item, dict) or not item for item in selector_alternatives):
-        raise ValueError(
-            f"Invalid selector alternative for component {index} in {ctx}: "
-            "expected non-empty objects"
-        )
-
-
-def _validate_aggregate_fallbacks(
-    group: dict[str, Any], *, index: int, ctx: str
-) -> None:
-    fallbacks = group.get("aggregate_fallbacks")
-    if fallbacks is None:
-        return
-    children = group.get("components")
-    if not isinstance(children, list):
-        raise ValueError(
-            f"Aggregate fallbacks are only valid on group components "
-            f"(index {index} in {ctx})"
-        )
-    aggregation = str(group.get("aggregation", "arithmetic")).lower()
-    if aggregation != "arithmetic":
-        raise ValueError(
-            f"Aggregate fallbacks require arithmetic group aggregation "
-            f"(index {index} in {ctx})"
-        )
-    if not isinstance(fallbacks, list) or not fallbacks:
-        raise ValueError(
-            f"Invalid aggregate fallbacks for component {index} in {ctx}: "
-            "expected a non-empty list"
-        )
-
-    child_labels = {
-        child.get("label")
-        for child in children
-        if isinstance(child, dict) and isinstance(child.get("label"), str)
-    }
-    for fallback_index, fallback in enumerate(fallbacks):
-        fallback_ctx = f"{ctx}.components[{index}].aggregate_fallbacks[{fallback_index}]"
-        if not isinstance(fallback, dict):
-            raise ValueError(f"Invalid aggregate fallback in {fallback_ctx}: expected object")
-        for key in ("benchmark", "metric", "label"):
-            if not isinstance(fallback.get(key), str) or not fallback[key].strip():
-                raise ValueError(
-                    f"Invalid aggregate fallback in {fallback_ctx}: "
-                    f"expected non-empty {key}"
-                )
-        if not isinstance(fallback.get("selector"), dict) or not fallback["selector"]:
-            raise ValueError(
-                f"Invalid aggregate fallback in {fallback_ctx}: "
-                "expected a non-empty selector"
-            )
-        _validate_selector_alternatives(fallback, index=fallback_index, ctx=fallback_ctx)
-
-        covers = fallback.get("covers")
-        if (
-            not isinstance(covers, list)
-            or not covers
-            or any(not isinstance(label, str) or not label for label in covers)
-            or len(set(covers)) != len(covers)
-            or any(label not in child_labels for label in covers)
-        ):
-            raise ValueError(
-                f"Invalid covered components in {fallback_ctx}: "
-                "expected unique child labels"
-            )
-
-        baseline_components = fallback.get("baseline_components")
-        if not isinstance(baseline_components, list) or not baseline_components:
-            raise ValueError(
-                f"Invalid baseline components in {fallback_ctx}: "
-                "expected a non-empty list"
-            )
-        baseline_weight = 0.0
-        for baseline_index, baseline_component in enumerate(baseline_components):
-            baseline_ctx = f"{fallback_ctx}.baseline_components[{baseline_index}]"
-            if not isinstance(baseline_component, dict):
-                raise ValueError(
-                    f"Invalid baseline component in {baseline_ctx}: expected object"
-                )
-            if (
-                not isinstance(baseline_component.get("selector"), dict)
-                or not baseline_component["selector"]
-            ):
-                raise ValueError(
-                    f"Invalid baseline component in {baseline_ctx}: "
-                    "expected a non-empty selector"
-                )
-            _validate_selector_alternatives(
-                baseline_component, index=baseline_index, ctx=baseline_ctx
-            )
-            try:
-                weight = _parse_weight(baseline_component.get("weight"))
-            except Exception:
-                raise ValueError(
-                    f"Invalid baseline component weight in {baseline_ctx}: "
-                    f"{baseline_component.get('weight')!r}"
-                )
-            if weight < 0:
-                raise ValueError(
-                    f"Negative baseline component weight in {baseline_ctx}: "
-                    f"{baseline_component.get('weight')!r}"
-                )
-            baseline_weight += weight
-        if abs(baseline_weight - 1.0) > 1e-9:
-            raise ValueError(
-                f"Baseline component weights must sum to 1.0 in {fallback_ctx}: "
-                f"got {baseline_weight}"
-            )
-
-        required = fallback.get("required_num_qubits")
-        if required is not None and (
-            isinstance(required, bool) or not isinstance(required, int) or required <= 0
-        ):
-            raise ValueError(
-                f"Invalid required_num_qubits in {fallback_ctx}: {required!r}"
-            )
-
-
 def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> None:
     total = 0.0
     for i, comp in enumerate(components):
@@ -929,8 +702,23 @@ def _validate_components_list(components: list[dict[str, Any]], ctx: str) -> Non
                     f"'aggregation' is only valid on group components (index {i} in {ctx})"
                 )
 
-        _validate_selector_alternatives(comp, index=i, ctx=ctx)
-        _validate_aggregate_fallbacks(comp, index=i, ctx=ctx)
+        selector_alternatives = comp.get("selector_alternatives")
+        if selector_alternatives is not None:
+            if not isinstance(comp.get("selector"), dict) or not comp["selector"]:
+                raise ValueError(
+                    f"Selector alternatives require a non-empty primary selector "
+                    f"(index {i} in {ctx})"
+                )
+            if not isinstance(selector_alternatives, list) or not selector_alternatives:
+                raise ValueError(
+                    f"Invalid selector alternatives for component {i} in {ctx}: "
+                    "expected a non-empty list"
+                )
+            if any(not isinstance(item, dict) or not item for item in selector_alternatives):
+                raise ValueError(
+                    f"Invalid selector alternative for component {i} in {ctx}: "
+                    "expected non-empty objects"
+                )
 
         if isinstance(children, list):
             _validate_components_list(children, ctx=f"{ctx}.components[{i}]")
@@ -1125,164 +913,6 @@ def _pick_latest_metric_row(
     return picked, picked_ts
 
 
-def _aggregate_fallback_baseline(
-    fallback: dict[str, Any],
-    series_label: str | None,
-    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
-) -> float | None:
-    """Build the like-for-like baseline declared for an aggregate fallback."""
-    fallback_benchmark = fallback.get("benchmark")
-    fallback_metric = fallback.get("metric")
-    baseline_components = fallback.get("baseline_components")
-    if (
-        not isinstance(fallback_benchmark, str)
-        or not isinstance(fallback_metric, str)
-        or not isinstance(baseline_components, list)
-    ):
-        return None
-
-    baseline_map = baseline_avg_by_series.get(series_label or "", {})
-    total = 0.0
-    total_weight = 0.0
-    for component in baseline_components:
-        if not isinstance(component, dict):
-            return None
-        benchmark = component.get("benchmark", fallback_benchmark)
-        metric = component.get("metric", fallback_metric)
-        selector = component.get("selector")
-        if (
-            not isinstance(benchmark, str)
-            or not isinstance(metric, str)
-            or not isinstance(selector, dict)
-            or not selector
-        ):
-            return None
-        try:
-            weight = _parse_weight(component.get("weight"))
-        except Exception:
-            return None
-        selector_fp = _selector_fingerprint(selector)
-        base = baseline_map.get((benchmark, metric, selector_fp))
-        if base is None:
-            base = _fallback_baseline_average(
-                series_label,
-                benchmark,
-                metric,
-                selector_fp,
-                baseline_avg_by_series,
-            )
-        if base is None:
-            return None
-        total += weight * base
-        total_weight += weight
-    if total_weight <= 0:
-        return None
-    return total / total_weight
-
-
-def _pick_group_aggregate_fallback(
-    group: dict[str, Any],
-    rows: list[dict[str, Any]],
-    row_series: dict[int, str],
-    row_major_by_id: dict[int, int | None],
-    picked_series: str | None,
-    picked_major: int | None,
-    scoring_cfg: dict[str, Any],
-    baseline_avg_by_series: dict[str, dict[tuple[str, str, str], float]],
-) -> dict[str, Any] | None:
-    """Pick the widest configured aggregate representation, then its latest row."""
-    items = group.get("items")
-    fallbacks = group.get("aggregate_fallbacks")
-    if not isinstance(items, list) or not isinstance(fallbacks, list):
-        return None
-
-    total_sub = sum(
-        float(item.get("sub_weight", 0.0))
-        for item in items
-        if isinstance(item, dict) and float(item.get("sub_weight", 0.0)) > 0
-    )
-    item_weights = {
-        item.get("label"): float(item.get("sub_weight", 0.0))
-        for item in items
-        if isinstance(item, dict) and isinstance(item.get("label"), str)
-    }
-    if total_sub <= 0:
-        return None
-
-    best: dict[str, Any] | None = None
-    best_coverage = -1.0
-    best_timestamp: datetime | None = None
-    for fallback in fallbacks:
-        if not isinstance(fallback, dict):
-            continue
-        covers = fallback.get("covers")
-        if not isinstance(covers, list) or any(label not in item_weights for label in covers):
-            continue
-        covered_sub = sum(item_weights[label] for label in covers)
-        if covered_sub <= 0:
-            continue
-        baseline = _aggregate_fallback_baseline(
-            fallback, picked_series, baseline_avg_by_series
-        )
-        if baseline is None:
-            continue
-        metric = fallback.get("metric")
-        if not isinstance(metric, str):
-            continue
-
-        matches: list[dict[str, Any]] = []
-        for row in rows:
-            if not _component_matches_benchmark(fallback, derive_benchmark_name(row)):
-                continue
-            if not _component_param_matches(fallback, row):
-                continue
-            series_label = row_series.get(id(row))
-            if picked_major is not None:
-                if row_major_by_id.get(id(row)) != picked_major:
-                    continue
-            elif series_label != picked_series:
-                continue
-            raw = _get_raw_metric_value(row, metric)
-            if raw is None:
-                continue
-            direction = _metric_direction(row, metric)
-            normalized: float | None = None
-            if _is_baseline_row_for_series(scoring_cfg, series_label, row):
-                normalized = 100.0
-            elif direction == "lower":
-                if raw > 0:
-                    normalized = 100.0 * baseline / raw
-            elif baseline > 0:
-                normalized = 100.0 * raw / baseline
-            if normalized is None:
-                continue
-            candidate = dict(row)
-            candidate["_raw_val"] = raw
-            candidate["_normalized_val"] = normalized
-            matches.append(candidate)
-
-        picked, timestamp = _pick_latest_metric_row(matches, "_raw_val")
-        if picked is None or timestamp is None:
-            continue
-        coverage = covered_sub / total_sub
-        if (
-            best is None
-            or coverage > best_coverage
-            or (coverage == best_coverage and (best_timestamp is None or timestamp > best_timestamp))
-        ):
-            best = {
-                "config": fallback,
-                "timestamp": picked.get("timestamp"),
-                "raw": float(picked["_raw_val"]),
-                "normalized": float(picked["_normalized_val"]),
-                "coverage": coverage,
-                "covered_components": list(covers),
-            }
-            best_coverage = coverage
-            best_timestamp = timestamp
-    return best
-
-
 def compute_device_composite_scores(
     flat_rows: list[dict[str, Any]],
     row_series: dict[int, str],
@@ -1458,13 +1088,7 @@ def compute_device_composite_scores(
                 group["items"].append((sub_weight, normalized_value))
             elif group_label is not None:
                 group = arithmetic_groups.setdefault(
-                    group_label,
-                    {
-                        "group_label": group_label,
-                        "group_weight": group_weight,
-                        "items": [],
-                        "aggregate_fallbacks": comp.get("_group_aggregate_fallbacks"),
-                    },
+                    group_label, {"group_weight": group_weight, "items": []}
                 )
                 group["items"].append(
                     {
@@ -1535,59 +1159,6 @@ def compute_device_composite_scores(
         for group in arithmetic_groups.values():
             items = group["items"]
             total_sub = sum(it["sub_weight"] for it in items if it["sub_weight"] > 0)
-            canonical_available = any(
-                it["raw"] is not None or it["normalized"] is not None for it in items
-            )
-            if not canonical_available:
-                fallback = _pick_group_aggregate_fallback(
-                    group,
-                    rows,
-                    row_series,
-                    row_major_by_id,
-                    picked_series,
-                    picked_major,
-                    scoring_cfg,
-                    baseline_avg_by_series,
-                )
-                if fallback is not None:
-                    fallback_cfg = fallback["config"]
-                    coverage = float(fallback["coverage"])
-                    value = float(fallback["normalized"])
-                    group_weight = float(group["group_weight"])
-                    numerator += group_weight * coverage * value
-                    for covered_label in fallback["covered_components"]:
-                        breakdown.pop(covered_label, None)
-
-                    label = str(fallback_cfg["label"])
-                    selector = fallback_cfg.get("selector")
-                    required = fallback_cfg.get("required_num_qubits")
-                    if not isinstance(required, int) and isinstance(selector, dict):
-                        for key in ("num_qubits", "width"):
-                            if isinstance(selector.get(key), int):
-                                required = selector[key]
-                                break
-                    breakdown[label] = {
-                        "metric": fallback_cfg["metric"],
-                        "weight": group_weight * coverage,
-                        "group": group.get("group_label"),
-                        "group_weight": group_weight,
-                        "sub_weight": coverage,
-                        "aggregation": "arithmetic",
-                        "timestamp": fallback["timestamp"],
-                        "normalized": value,
-                        "normalized_available": True,
-                        "normalized_timestamp": fallback["timestamp"],
-                        "raw": fallback["raw"],
-                        "raw_available": True,
-                        "raw_timestamp": fallback["timestamp"],
-                        "group_subscore": value,
-                        "aggregate_fallback": True,
-                        "coverage": coverage,
-                        "covered_components": fallback["covered_components"],
-                    }
-                    if isinstance(required, int):
-                        breakdown[label]["required_num_qubits"] = required
-                    continue
             subscore = _benchmark_subscore(items) if total_sub > 0 else None
             if subscore is None:
                 # No width has both a device and a baseline raw value (for example

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -374,68 +374,6 @@
                 "label": "QFT-20:score",
                 "weight": "5/11"
               }
-            ],
-            "aggregate_fallbacks": [
-              {
-                "benchmark": "Quantum Fourier Transform",
-                "metric": "score",
-                "selector": { "min_qubits": 4, "max_qubits": 12, "skip_qubits": 4 },
-                "label": "QFT (legacy 4–12 sweep):score",
-                "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
-                "required_num_qubits": 12,
-                "baseline_components": [
-                  {
-                    "selector": { "num_qubits": 4 },
-                    "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
-                    "weight": "1/3"
-                  },
-                  {
-                    "selector": { "num_qubits": 8 },
-                    "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
-                    "weight": "1/3"
-                  },
-                  {
-                    "selector": { "num_qubits": 12 },
-                    "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
-                    "weight": "1/3"
-                  }
-                ]
-              },
-              {
-                "benchmark": "Quantum Fourier Transform",
-                "metric": "score",
-                "selector": { "min_qubits": 4, "max_qubits": 20, "skip_qubits": 4 },
-                "label": "QFT (legacy 4–20 sweep):score",
-                "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score", "QFT-20:score"],
-                "required_num_qubits": 20,
-                "baseline_components": [
-                  {
-                    "selector": { "num_qubits": 4 },
-                    "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
-                    "weight": "1/5"
-                  },
-                  {
-                    "selector": { "num_qubits": 8 },
-                    "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
-                    "weight": "1/5"
-                  },
-                  {
-                    "selector": { "num_qubits": 12 },
-                    "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
-                    "weight": "1/5"
-                  },
-                  {
-                    "selector": { "num_qubits": 16 },
-                    "selector_alternatives": [{ "min_qubits": 16, "max_qubits": 16 }],
-                    "weight": "1/5"
-                  },
-                  {
-                    "selector": { "num_qubits": 20 },
-                    "selector_alternatives": [{ "min_qubits": 20, "max_qubits": 20 }],
-                    "weight": "1/5"
-                  }
-                ]
-              }
             ]
           },
           {
@@ -680,68 +618,6 @@
               ],
               "label": "QFT-20:score",
               "weight": "5/11"
-            }
-          ],
-          "aggregate_fallbacks": [
-            {
-              "benchmark": "Quantum Fourier Transform",
-              "metric": "score",
-              "selector": { "min_qubits": 4, "max_qubits": 12, "skip_qubits": 4 },
-              "label": "QFT (legacy 4–12 sweep):score",
-              "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
-              "required_num_qubits": 12,
-              "baseline_components": [
-                {
-                  "selector": { "num_qubits": 4 },
-                  "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
-                  "weight": "1/3"
-                },
-                {
-                  "selector": { "num_qubits": 8 },
-                  "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
-                  "weight": "1/3"
-                },
-                {
-                  "selector": { "num_qubits": 12 },
-                  "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
-                  "weight": "1/3"
-                }
-              ]
-            },
-            {
-              "benchmark": "Quantum Fourier Transform",
-              "metric": "score",
-              "selector": { "min_qubits": 4, "max_qubits": 20, "skip_qubits": 4 },
-              "label": "QFT (legacy 4–20 sweep):score",
-              "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score", "QFT-20:score"],
-              "required_num_qubits": 20,
-              "baseline_components": [
-                {
-                  "selector": { "num_qubits": 4 },
-                  "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
-                  "weight": "1/5"
-                },
-                {
-                  "selector": { "num_qubits": 8 },
-                  "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
-                  "weight": "1/5"
-                },
-                {
-                  "selector": { "num_qubits": 12 },
-                  "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
-                  "weight": "1/5"
-                },
-                {
-                  "selector": { "num_qubits": 16 },
-                  "selector_alternatives": [{ "min_qubits": 16, "max_qubits": 16 }],
-                  "weight": "1/5"
-                },
-                {
-                  "selector": { "num_qubits": 20 },
-                  "selector_alternatives": [{ "min_qubits": 20, "max_qubits": 20 }],
-                  "weight": "1/5"
-                }
-              ]
             }
           ]
         },

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -374,6 +374,68 @@
                 "label": "QFT-20:score",
                 "weight": "5/11"
               }
+            ],
+            "aggregate_fallbacks": [
+              {
+                "benchmark": "Quantum Fourier Transform",
+                "metric": "score",
+                "selector": { "min_qubits": 4, "max_qubits": 12, "skip_qubits": 4 },
+                "label": "QFT (legacy 4–12 sweep):score",
+                "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
+                "required_num_qubits": 12,
+                "baseline_components": [
+                  {
+                    "selector": { "num_qubits": 4 },
+                    "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
+                    "weight": "1/3"
+                  },
+                  {
+                    "selector": { "num_qubits": 8 },
+                    "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
+                    "weight": "1/3"
+                  },
+                  {
+                    "selector": { "num_qubits": 12 },
+                    "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
+                    "weight": "1/3"
+                  }
+                ]
+              },
+              {
+                "benchmark": "Quantum Fourier Transform",
+                "metric": "score",
+                "selector": { "min_qubits": 4, "max_qubits": 20, "skip_qubits": 4 },
+                "label": "QFT (legacy 4–20 sweep):score",
+                "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score", "QFT-20:score"],
+                "required_num_qubits": 20,
+                "baseline_components": [
+                  {
+                    "selector": { "num_qubits": 4 },
+                    "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
+                    "weight": "1/5"
+                  },
+                  {
+                    "selector": { "num_qubits": 8 },
+                    "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
+                    "weight": "1/5"
+                  },
+                  {
+                    "selector": { "num_qubits": 12 },
+                    "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
+                    "weight": "1/5"
+                  },
+                  {
+                    "selector": { "num_qubits": 16 },
+                    "selector_alternatives": [{ "min_qubits": 16, "max_qubits": 16 }],
+                    "weight": "1/5"
+                  },
+                  {
+                    "selector": { "num_qubits": 20 },
+                    "selector_alternatives": [{ "min_qubits": 20, "max_qubits": 20 }],
+                    "weight": "1/5"
+                  }
+                ]
+              }
             ]
           },
           {
@@ -618,6 +680,68 @@
               ],
               "label": "QFT-20:score",
               "weight": "5/11"
+            }
+          ],
+          "aggregate_fallbacks": [
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": { "min_qubits": 4, "max_qubits": 12, "skip_qubits": 4 },
+              "label": "QFT (legacy 4–12 sweep):score",
+              "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
+              "required_num_qubits": 12,
+              "baseline_components": [
+                {
+                  "selector": { "num_qubits": 4 },
+                  "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
+                  "weight": "1/3"
+                },
+                {
+                  "selector": { "num_qubits": 8 },
+                  "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
+                  "weight": "1/3"
+                },
+                {
+                  "selector": { "num_qubits": 12 },
+                  "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
+                  "weight": "1/3"
+                }
+              ]
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": { "min_qubits": 4, "max_qubits": 20, "skip_qubits": 4 },
+              "label": "QFT (legacy 4–20 sweep):score",
+              "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score", "QFT-20:score"],
+              "required_num_qubits": 20,
+              "baseline_components": [
+                {
+                  "selector": { "num_qubits": 4 },
+                  "selector_alternatives": [{ "min_qubits": 4, "max_qubits": 4 }],
+                  "weight": "1/5"
+                },
+                {
+                  "selector": { "num_qubits": 8 },
+                  "selector_alternatives": [{ "min_qubits": 8, "max_qubits": 8 }],
+                  "weight": "1/5"
+                },
+                {
+                  "selector": { "num_qubits": 12 },
+                  "selector_alternatives": [{ "min_qubits": 12, "max_qubits": 12 }],
+                  "weight": "1/5"
+                },
+                {
+                  "selector": { "num_qubits": 16 },
+                  "selector_alternatives": [{ "min_qubits": 16, "max_qubits": 16 }],
+                  "weight": "1/5"
+                },
+                {
+                  "selector": { "num_qubits": 20 },
+                  "selector_alternatives": [{ "min_qubits": 20, "max_qubits": 20 }],
+                  "weight": "1/5"
+                }
+              ]
             }
           ]
         },

--- a/scripts/scoring.json
+++ b/scripts/scoring.json
@@ -337,8 +337,42 @@
               {
                 "benchmark": "Quantum Fourier Transform",
                 "metric": "score",
-                "label": "Quantum Fourier Transform:score",
-                "weight": "1/1"
+                "selector": { "num_qubits": 4 },
+                "selector_alternatives": [
+                  { "min_qubits": 4, "max_qubits": 4 }
+                ],
+                "label": "QFT-4:score",
+                "weight": "1/11"
+              },
+              {
+                "benchmark": "Quantum Fourier Transform",
+                "metric": "score",
+                "selector": { "num_qubits": 8 },
+                "selector_alternatives": [
+                  { "min_qubits": 8, "max_qubits": 8 }
+                ],
+                "label": "QFT-8:score",
+                "weight": "2/11"
+              },
+              {
+                "benchmark": "Quantum Fourier Transform",
+                "metric": "score",
+                "selector": { "num_qubits": 12 },
+                "selector_alternatives": [
+                  { "min_qubits": 12, "max_qubits": 12 }
+                ],
+                "label": "QFT-12:score",
+                "weight": "3/11"
+              },
+              {
+                "benchmark": "Quantum Fourier Transform",
+                "metric": "score",
+                "selector": { "num_qubits": 20 },
+                "selector_alternatives": [
+                  { "min_qubits": 20, "max_qubits": 20 }
+                ],
+                "label": "QFT-20:score",
+                "weight": "5/11"
               }
             ]
           },
@@ -548,8 +582,42 @@
             {
               "benchmark": "Quantum Fourier Transform",
               "metric": "score",
-              "label": "Quantum Fourier Transform:score",
-              "weight": "1/1"
+              "selector": { "num_qubits": 4 },
+              "selector_alternatives": [
+                { "min_qubits": 4, "max_qubits": 4 }
+              ],
+              "label": "QFT-4:score",
+              "weight": "1/11"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": { "num_qubits": 8 },
+              "selector_alternatives": [
+                { "min_qubits": 8, "max_qubits": 8 }
+              ],
+              "label": "QFT-8:score",
+              "weight": "2/11"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": { "num_qubits": 12 },
+              "selector_alternatives": [
+                { "min_qubits": 12, "max_qubits": 12 }
+              ],
+              "label": "QFT-12:score",
+              "weight": "3/11"
+            },
+            {
+              "benchmark": "Quantum Fourier Transform",
+              "metric": "score",
+              "selector": { "num_qubits": 20 },
+              "selector_alternatives": [
+                { "min_qubits": 20, "max_qubits": 20 }
+              ],
+              "label": "QFT-20:score",
+              "weight": "5/11"
             }
           ]
         },

--- a/tests/test_qft_scoring.py
+++ b/tests/test_qft_scoring.py
@@ -16,12 +16,57 @@ from score import (  # noqa: E402
     compute_and_attach_metriq_scores,
     compute_baseline_averages_by_series,
     compute_device_composite_scores,
+    validate_scoring_config,
 )
 
 
 BENCH = "Quantum Fourier Transform"
 WIDTHS = [4, 8, 12, 20]
 WEIGHTS = [1 / 11, 2 / 11, 3 / 11, 5 / 11]
+
+
+def _legacy_baseline_component(width, weight):
+    return {
+        "selector": {"num_qubits": width},
+        "selector_alternatives": [
+            {"min_qubits": width, "max_qubits": width}
+        ],
+        "weight": weight,
+    }
+
+
+def _aggregate_fallbacks():
+    return [
+        {
+            "benchmark": BENCH,
+            "metric": "score",
+            "selector": {"min_qubits": 4, "max_qubits": 12, "skip_qubits": 4},
+            "label": "QFT (legacy 4–12 sweep):score",
+            "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
+            "required_num_qubits": 12,
+            "baseline_components": [
+                _legacy_baseline_component(width, "1/3")
+                for width in (4, 8, 12)
+            ],
+        },
+        {
+            "benchmark": BENCH,
+            "metric": "score",
+            "selector": {"min_qubits": 4, "max_qubits": 20, "skip_qubits": 4},
+            "label": "QFT (legacy 4–20 sweep):score",
+            "covers": [
+                "QFT-4:score",
+                "QFT-8:score",
+                "QFT-12:score",
+                "QFT-20:score",
+            ],
+            "required_num_qubits": 20,
+            "baseline_components": [
+                _legacy_baseline_component(width, "1/5")
+                for width in (4, 8, 12, 16, 20)
+            ],
+        },
+    ]
 
 
 def _qft_group(weight="1"):
@@ -41,6 +86,7 @@ def _qft_group(weight="1"):
             }
             for width in WIDTHS
         ],
+        "aggregate_fallbacks": _aggregate_fallbacks(),
     }
 
 
@@ -53,18 +99,42 @@ def _scoring_cfg():
     }
 
 
-def _row(device, width, value, *, legacy):
+def _row(device, width, value, *, legacy, provider="ibm"):
     params = (
         {"min_qubits": width, "max_qubits": width, "skip_qubits": 1}
         if legacy
         else {"num_qubits": width}
     )
     return {
-        "provider": "ibm",
+        "provider": provider,
         "device": device,
         "timestamp": f"2026-01-01T00:00:{width:02d}",
         "job_type": BENCH,
         "params": params,
+        "results": {"score": value},
+        "directions": {"score": "higher"},
+    }
+
+
+def _aggregate_row(
+    device,
+    max_qubits,
+    value,
+    *,
+    provider="quantinuum",
+    timestamp="2025-12-08T10:03:08.711173",
+):
+    return {
+        "provider": provider,
+        "device": device,
+        "timestamp": timestamp,
+        "job_type": BENCH,
+        "params": {
+            "min_qubits": 4,
+            "max_qubits": max_qubits,
+            "skip_qubits": 4,
+            "max_circuits": 3,
+        },
         "results": {"score": value},
         "directions": {"score": "higher"},
     }
@@ -167,9 +237,135 @@ class QFTCompositeTests(unittest.TestCase):
             records["ibm_boston"]["components"]["QFT-20:score"]["raw_available"]
         )
 
+    def test_quantinuum_legacy_sweep_is_scored_without_inventing_width_values(self):
+        baseline_values = {4: 0.808, 8: 0.215, 12: 0.002, 20: 0.0}
+        baseline_rows = [
+            _row("ibm_torino", width, value, legacy=True)
+            for width, value in baseline_values.items()
+        ]
+        quantinuum_row = _aggregate_row("H2-2", 12, 0.967)
+        rows = [*baseline_rows, quantinuum_row]
+        row_series = {
+            **{id(row): "v0.6" for row in baseline_rows},
+            id(quantinuum_row): "v0.5",
+        }
+        scoring_cfg = _scoring_cfg()
+        baseline_avg, _ = compute_baseline_averages_by_series(
+            rows, row_series, scoring_cfg
+        )
+        compute_and_attach_metriq_scores(
+            rows, row_series, baseline_avg, scoring_cfg
+        )
+
+        records = {
+            record["device"]: record
+            for record in compute_device_composite_scores(
+                rows, row_series, baseline_avg, scoring_cfg
+            )
+        }
+        quantinuum = records["H2-2"]
+        fallback_label = "QFT (legacy 4–12 sweep):score"
+        component = quantinuum["components"][fallback_label]
+        baseline_sweep = (0.808 + 0.215 + 0.002) / 3
+        normalized = 100.0 * 0.967 / baseline_sweep
+        coverage = 6 / 11
+
+        self.assertAlmostEqual(quantinuum_row["normalized_scores"]["score"], normalized)
+        self.assertAlmostEqual(quantinuum_row["metriq_score"], normalized)
+        self.assertAlmostEqual(component["raw"], 0.967)
+        self.assertAlmostEqual(component["normalized"], normalized)
+        self.assertAlmostEqual(component["coverage"], coverage)
+        self.assertAlmostEqual(component["weight"], coverage)
+        self.assertEqual(component["required_num_qubits"], 12)
+        self.assertTrue(component["aggregate_fallback"])
+        self.assertEqual(
+            component["covered_components"],
+            ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
+        )
+        self.assertNotIn("QFT-4:score", quantinuum["components"])
+        self.assertNotIn("QFT-8:score", quantinuum["components"])
+        self.assertNotIn("QFT-12:score", quantinuum["components"])
+        self.assertFalse(
+            quantinuum["components"]["QFT-20:score"]["raw_available"]
+        )
+        self.assertAlmostEqual(quantinuum["metriq_score"], normalized * coverage)
+
+    def test_canonical_width_data_takes_precedence_over_legacy_sweep(self):
+        baseline_rows = [
+            _row("ibm_torino", width, value, legacy=True)
+            for width, value in zip(WIDTHS, [0.808, 0.215, 0.002, 0.0])
+        ]
+        quantinuum_sweep = _aggregate_row("H2-2", 12, 0.967)
+        quantinuum_width = _row(
+            "H2-2", 4, 0.9, legacy=False, provider="quantinuum"
+        )
+        rows = [*baseline_rows, quantinuum_sweep, quantinuum_width]
+        row_series = {id(row): "v0.6" for row in rows}
+        scoring_cfg = _scoring_cfg()
+        baseline_avg, _ = compute_baseline_averages_by_series(
+            rows, row_series, scoring_cfg
+        )
+
+        quantinuum = next(
+            record
+            for record in compute_device_composite_scores(
+                rows, row_series, baseline_avg, scoring_cfg
+            )
+            if record["device"] == "H2-2"
+        )
+
+        self.assertNotIn(
+            "QFT (legacy 4–12 sweep):score", quantinuum["components"]
+        )
+        self.assertEqual(quantinuum["components"]["QFT-4:score"]["raw"], 0.9)
+
+    def test_widest_legacy_sweep_wins_and_uses_its_full_baseline(self):
+        baseline_values = {4: 0.8, 8: 0.4, 12: 0.2, 16: 0.1, 20: 0.05}
+        baseline_rows = [
+            _row("ibm_torino", width, value, legacy=True)
+            for width, value in baseline_values.items()
+        ]
+        full_sweep = _aggregate_row(
+            "legacy-device",
+            20,
+            0.5,
+            provider="origin",
+            timestamp="2026-01-01T00:00:01",
+        )
+        newer_partial_sweep = _aggregate_row(
+            "legacy-device",
+            12,
+            0.9,
+            provider="origin",
+            timestamp="2026-01-02T00:00:01",
+        )
+        rows = [*baseline_rows, full_sweep, newer_partial_sweep]
+        row_series = {id(row): "v0.6" for row in rows}
+        scoring_cfg = _scoring_cfg()
+        baseline_avg, _ = compute_baseline_averages_by_series(
+            rows, row_series, scoring_cfg
+        )
+
+        record = next(
+            record
+            for record in compute_device_composite_scores(
+                rows, row_series, baseline_avg, scoring_cfg
+            )
+            if record["device"] == "legacy-device"
+        )
+        component = record["components"]["QFT (legacy 4–20 sweep):score"]
+        expected_baseline = sum(baseline_values.values()) / 5
+
+        self.assertNotIn("QFT (legacy 4–12 sweep):score", record["components"])
+        self.assertAlmostEqual(component["normalized"], 100.0 * 0.5 / expected_baseline)
+        self.assertAlmostEqual(component["coverage"], 1.0)
+        self.assertEqual(component["required_num_qubits"], 20)
+
     def test_published_qft_panels_follow_the_score_definition(self):
         with (ROOT / "scripts" / "scoring.json").open(encoding="utf-8") as f:
             scoring_cfg = json.load(f)
+
+        validate_scoring_config(scoring_cfg)
 
         for block_name in ("default", "v1.0"):
             block = (
@@ -200,6 +396,28 @@ class QFTCompositeTests(unittest.TestCase):
                 [_parse_weight(child["weight"]) for child in qft_group["components"]],
                 WEIGHTS,
             )
+            self.assertEqual(
+                [
+                    fallback["selector"]
+                    for fallback in qft_group["aggregate_fallbacks"]
+                ],
+                [
+                    {"min_qubits": 4, "max_qubits": 12, "skip_qubits": 4},
+                    {"min_qubits": 4, "max_qubits": 20, "skip_qubits": 4},
+                ],
+            )
+            self.assertEqual(
+                [fallback["covers"] for fallback in qft_group["aggregate_fallbacks"]],
+                [
+                    ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
+                    [
+                        "QFT-4:score",
+                        "QFT-8:score",
+                        "QFT-12:score",
+                        "QFT-20:score",
+                    ],
+                ],
+            )
 
         legacy_qft_group = next(
             group
@@ -208,6 +426,54 @@ class QFTCompositeTests(unittest.TestCase):
         )
         self.assertEqual(len(legacy_qft_group["components"]), 1)
         self.assertNotIn("selector", legacy_qft_group["components"][0])
+
+
+class AggregateFallbackValidationTests(unittest.TestCase):
+    def test_covered_components_must_reference_group_children(self):
+        scoring_cfg = _scoring_cfg()
+        scoring_cfg["default"]["composite"]["components"][0][
+            "aggregate_fallbacks"
+        ][0]["covers"] = ["not-a-child"]
+
+        with self.assertRaisesRegex(ValueError, "Invalid covered components"):
+            validate_scoring_config(scoring_cfg)
+
+    def test_baseline_component_weights_must_sum_to_one(self):
+        scoring_cfg = _scoring_cfg()
+        scoring_cfg["default"]["composite"]["components"][0][
+            "aggregate_fallbacks"
+        ][0]["baseline_components"][0]["weight"] = "1/2"
+
+        with self.assertRaisesRegex(
+            ValueError, "Baseline component weights must sum to 1.0"
+        ):
+            validate_scoring_config(scoring_cfg)
+
+    def test_overlapping_fallbacks_for_one_metric_are_rejected_at_runtime(self):
+        scoring_cfg = _scoring_cfg()
+        fallbacks = scoring_cfg["default"]["composite"]["components"][0][
+            "aggregate_fallbacks"
+        ]
+        overlapping = json.loads(json.dumps(fallbacks[0]))
+        overlapping["selector"] = {"min_qubits": 4}
+        overlapping["label"] = "overlapping aggregate"
+        fallbacks.append(overlapping)
+
+        baseline_rows = [
+            _row("ibm_torino", width, value, legacy=True)
+            for width, value in zip(WIDTHS, [0.808, 0.215, 0.002, 0.0])
+        ]
+        aggregate_row = _aggregate_row("H2-2", 12, 0.967)
+        rows = [*baseline_rows, aggregate_row]
+        row_series = {id(row): "v0.6" for row in rows}
+        baseline_avg, _ = compute_baseline_averages_by_series(
+            rows, row_series, scoring_cfg
+        )
+
+        with self.assertRaisesRegex(ValueError, "Ambiguous aggregate fallbacks"):
+            compute_and_attach_metriq_scores(
+                rows, row_series, baseline_avg, scoring_cfg
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_qft_scoring.py
+++ b/tests/test_qft_scoring.py
@@ -1,0 +1,214 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score import (  # noqa: E402
+    _component_param_matches,
+    _parse_weight,
+    _row_param_matches,
+    _selector_fingerprint,
+    compute_and_attach_metriq_scores,
+    compute_baseline_averages_by_series,
+    compute_device_composite_scores,
+)
+
+
+BENCH = "Quantum Fourier Transform"
+WIDTHS = [4, 8, 12, 20]
+WEIGHTS = [1 / 11, 2 / 11, 3 / 11, 5 / 11]
+
+
+def _qft_group(weight="1"):
+    return {
+        "label": BENCH,
+        "weight": weight,
+        "components": [
+            {
+                "benchmark": BENCH,
+                "metric": "score",
+                "selector": {"num_qubits": width},
+                "selector_alternatives": [
+                    {"min_qubits": width, "max_qubits": width}
+                ],
+                "label": f"QFT-{width}:score",
+                "weight": f"{width}/44",
+            }
+            for width in WIDTHS
+        ],
+    }
+
+
+def _scoring_cfg():
+    return {
+        "default": {
+            "baseline": {"provider": "ibm", "device": "ibm_torino"},
+            "composite": {"components": [_qft_group()]},
+        }
+    }
+
+
+def _row(device, width, value, *, legacy):
+    params = (
+        {"min_qubits": width, "max_qubits": width, "skip_qubits": 1}
+        if legacy
+        else {"num_qubits": width}
+    )
+    return {
+        "provider": "ibm",
+        "device": device,
+        "timestamp": f"2026-01-01T00:00:{width:02d}",
+        "job_type": BENCH,
+        "params": params,
+        "results": {"score": value},
+        "directions": {"score": "higher"},
+    }
+
+
+class QFTParameterCompatibilityTests(unittest.TestCase):
+    def test_num_qubits_selector_matches_current_schema(self):
+        row = _row("device", 8, 0.5, legacy=False)
+        self.assertTrue(_component_param_matches(_qft_group()["components"][1], row))
+        self.assertFalse(_component_param_matches(_qft_group()["components"][2], row))
+
+    def test_num_qubits_selector_matches_legacy_fixed_width(self):
+        row = _row("device", 8, 0.5, legacy=True)
+        component = _qft_group()["components"][1]
+        self.assertFalse(_row_param_matches(component["selector"], row))
+        self.assertTrue(_component_param_matches(component, row))
+        self.assertFalse(_component_param_matches(_qft_group()["components"][2], row))
+
+    def test_legacy_multi_width_result_is_not_misrepresented_as_one_width(self):
+        row = _row("device", 8, 0.5, legacy=True)
+        row["params"].update({"min_qubits": 4, "max_qubits": 12, "skip_qubits": 2})
+        for component in _qft_group()["components"][:3]:
+            self.assertFalse(_component_param_matches(component, row))
+
+    def test_alternative_selectors_are_benchmark_agnostic(self):
+        component = {
+            "selector": {"current_size": 8},
+            "selector_alternatives": [{"legacy_min": 8, "legacy_max": 8}],
+        }
+        row = {"params": {"legacy_min": 8, "legacy_max": 8}}
+        self.assertTrue(_component_param_matches(component, row))
+
+
+class QFTCompositeTests(unittest.TestCase):
+    def test_mixed_legacy_and_current_rows_use_all_canonical_widths(self):
+        baseline_values = [0.808, 0.215, 0.002, 0.0]
+        device_values = [0.862, 0.420, 0.038, 0.0]
+        rows = [
+            *[
+                _row("ibm_torino", width, value, legacy=True)
+                for width, value in zip(WIDTHS, baseline_values)
+            ],
+            *[
+                _row("ibm_boston", width, value, legacy=False)
+                for width, value in zip(WIDTHS, device_values)
+            ],
+        ]
+        row_series = {id(row): "v0.7" for row in rows}
+        scoring_cfg = _scoring_cfg()
+        baseline_avg, _ = compute_baseline_averages_by_series(
+            rows, row_series, scoring_cfg
+        )
+        baseline_keys = baseline_avg["v0.7"]
+        for width, value in zip(WIDTHS, baseline_values):
+            canonical_key = (
+                BENCH,
+                "score",
+                _selector_fingerprint({"num_qubits": width}),
+            )
+            self.assertEqual(baseline_keys[canonical_key], value)
+            self.assertNotIn(
+                (
+                    BENCH,
+                    "score",
+                    _selector_fingerprint(
+                        {"min_qubits": width, "max_qubits": width}
+                    ),
+                ),
+                baseline_keys,
+            )
+        compute_and_attach_metriq_scores(
+            rows, row_series, baseline_avg, scoring_cfg
+        )
+
+        records = {
+            record["device"]: record
+            for record in compute_device_composite_scores(
+                rows, row_series, baseline_avg, scoring_cfg
+            )
+        }
+        baseline_raw = sum(w * value for w, value in zip(WEIGHTS, baseline_values))
+        device_raw = sum(w * value for w, value in zip(WEIGHTS, device_values))
+
+        self.assertAlmostEqual(records["ibm_torino"]["metriq_score"], 100.0)
+        self.assertAlmostEqual(
+            records["ibm_boston"]["metriq_score"],
+            100.0 * device_raw / baseline_raw,
+        )
+        self.assertEqual(len(records["ibm_boston"]["components"]), 4)
+        self.assertEqual(
+            [
+                records["ibm_boston"]["components"][f"QFT-{width}:score"][
+                    "required_num_qubits"
+                ]
+                for width in WIDTHS
+            ],
+            WIDTHS,
+        )
+        self.assertTrue(
+            records["ibm_boston"]["components"]["QFT-20:score"]["raw_available"]
+        )
+
+    def test_published_qft_panels_follow_the_score_definition(self):
+        with (ROOT / "scripts" / "scoring.json").open(encoding="utf-8") as f:
+            scoring_cfg = json.load(f)
+
+        for block_name in ("default", "v1.0"):
+            block = (
+                scoring_cfg["default"]
+                if block_name == "default"
+                else scoring_cfg["series"][block_name]
+            )
+            qft_group = next(
+                group
+                for group in block["composite"]["components"]
+                if group.get("label") == BENCH
+            )
+            self.assertEqual(
+                [child["selector"]["num_qubits"] for child in qft_group["components"]],
+                WIDTHS,
+            )
+            self.assertEqual(
+                [
+                    child["selector_alternatives"]
+                    for child in qft_group["components"]
+                ],
+                [
+                    [{"min_qubits": width, "max_qubits": width}]
+                    for width in WIDTHS
+                ],
+            )
+            self.assertEqual(
+                [_parse_weight(child["weight"]) for child in qft_group["components"]],
+                WEIGHTS,
+            )
+
+        legacy_qft_group = next(
+            group
+            for group in scoring_cfg["series"]["v0.4"]["composite"]["components"]
+            if group.get("label") == BENCH
+        )
+        self.assertEqual(len(legacy_qft_group["components"]), 1)
+        self.assertNotIn("selector", legacy_qft_group["components"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qft_scoring.py
+++ b/tests/test_qft_scoring.py
@@ -16,57 +16,12 @@ from score import (  # noqa: E402
     compute_and_attach_metriq_scores,
     compute_baseline_averages_by_series,
     compute_device_composite_scores,
-    validate_scoring_config,
 )
 
 
 BENCH = "Quantum Fourier Transform"
 WIDTHS = [4, 8, 12, 20]
 WEIGHTS = [1 / 11, 2 / 11, 3 / 11, 5 / 11]
-
-
-def _legacy_baseline_component(width, weight):
-    return {
-        "selector": {"num_qubits": width},
-        "selector_alternatives": [
-            {"min_qubits": width, "max_qubits": width}
-        ],
-        "weight": weight,
-    }
-
-
-def _aggregate_fallbacks():
-    return [
-        {
-            "benchmark": BENCH,
-            "metric": "score",
-            "selector": {"min_qubits": 4, "max_qubits": 12, "skip_qubits": 4},
-            "label": "QFT (legacy 4–12 sweep):score",
-            "covers": ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
-            "required_num_qubits": 12,
-            "baseline_components": [
-                _legacy_baseline_component(width, "1/3")
-                for width in (4, 8, 12)
-            ],
-        },
-        {
-            "benchmark": BENCH,
-            "metric": "score",
-            "selector": {"min_qubits": 4, "max_qubits": 20, "skip_qubits": 4},
-            "label": "QFT (legacy 4–20 sweep):score",
-            "covers": [
-                "QFT-4:score",
-                "QFT-8:score",
-                "QFT-12:score",
-                "QFT-20:score",
-            ],
-            "required_num_qubits": 20,
-            "baseline_components": [
-                _legacy_baseline_component(width, "1/5")
-                for width in (4, 8, 12, 16, 20)
-            ],
-        },
-    ]
 
 
 def _qft_group(weight="1"):
@@ -86,7 +41,6 @@ def _qft_group(weight="1"):
             }
             for width in WIDTHS
         ],
-        "aggregate_fallbacks": _aggregate_fallbacks(),
     }
 
 
@@ -99,42 +53,18 @@ def _scoring_cfg():
     }
 
 
-def _row(device, width, value, *, legacy, provider="ibm"):
+def _row(device, width, value, *, legacy):
     params = (
         {"min_qubits": width, "max_qubits": width, "skip_qubits": 1}
         if legacy
         else {"num_qubits": width}
     )
     return {
-        "provider": provider,
+        "provider": "ibm",
         "device": device,
         "timestamp": f"2026-01-01T00:00:{width:02d}",
         "job_type": BENCH,
         "params": params,
-        "results": {"score": value},
-        "directions": {"score": "higher"},
-    }
-
-
-def _aggregate_row(
-    device,
-    max_qubits,
-    value,
-    *,
-    provider="quantinuum",
-    timestamp="2025-12-08T10:03:08.711173",
-):
-    return {
-        "provider": provider,
-        "device": device,
-        "timestamp": timestamp,
-        "job_type": BENCH,
-        "params": {
-            "min_qubits": 4,
-            "max_qubits": max_qubits,
-            "skip_qubits": 4,
-            "max_circuits": 3,
-        },
         "results": {"score": value},
         "directions": {"score": "higher"},
     }
@@ -237,135 +167,9 @@ class QFTCompositeTests(unittest.TestCase):
             records["ibm_boston"]["components"]["QFT-20:score"]["raw_available"]
         )
 
-    def test_quantinuum_legacy_sweep_is_scored_without_inventing_width_values(self):
-        baseline_values = {4: 0.808, 8: 0.215, 12: 0.002, 20: 0.0}
-        baseline_rows = [
-            _row("ibm_torino", width, value, legacy=True)
-            for width, value in baseline_values.items()
-        ]
-        quantinuum_row = _aggregate_row("H2-2", 12, 0.967)
-        rows = [*baseline_rows, quantinuum_row]
-        row_series = {
-            **{id(row): "v0.6" for row in baseline_rows},
-            id(quantinuum_row): "v0.5",
-        }
-        scoring_cfg = _scoring_cfg()
-        baseline_avg, _ = compute_baseline_averages_by_series(
-            rows, row_series, scoring_cfg
-        )
-        compute_and_attach_metriq_scores(
-            rows, row_series, baseline_avg, scoring_cfg
-        )
-
-        records = {
-            record["device"]: record
-            for record in compute_device_composite_scores(
-                rows, row_series, baseline_avg, scoring_cfg
-            )
-        }
-        quantinuum = records["H2-2"]
-        fallback_label = "QFT (legacy 4–12 sweep):score"
-        component = quantinuum["components"][fallback_label]
-        baseline_sweep = (0.808 + 0.215 + 0.002) / 3
-        normalized = 100.0 * 0.967 / baseline_sweep
-        coverage = 6 / 11
-
-        self.assertAlmostEqual(quantinuum_row["normalized_scores"]["score"], normalized)
-        self.assertAlmostEqual(quantinuum_row["metriq_score"], normalized)
-        self.assertAlmostEqual(component["raw"], 0.967)
-        self.assertAlmostEqual(component["normalized"], normalized)
-        self.assertAlmostEqual(component["coverage"], coverage)
-        self.assertAlmostEqual(component["weight"], coverage)
-        self.assertEqual(component["required_num_qubits"], 12)
-        self.assertTrue(component["aggregate_fallback"])
-        self.assertEqual(
-            component["covered_components"],
-            ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
-        )
-        self.assertNotIn("QFT-4:score", quantinuum["components"])
-        self.assertNotIn("QFT-8:score", quantinuum["components"])
-        self.assertNotIn("QFT-12:score", quantinuum["components"])
-        self.assertFalse(
-            quantinuum["components"]["QFT-20:score"]["raw_available"]
-        )
-        self.assertAlmostEqual(quantinuum["metriq_score"], normalized * coverage)
-
-    def test_canonical_width_data_takes_precedence_over_legacy_sweep(self):
-        baseline_rows = [
-            _row("ibm_torino", width, value, legacy=True)
-            for width, value in zip(WIDTHS, [0.808, 0.215, 0.002, 0.0])
-        ]
-        quantinuum_sweep = _aggregate_row("H2-2", 12, 0.967)
-        quantinuum_width = _row(
-            "H2-2", 4, 0.9, legacy=False, provider="quantinuum"
-        )
-        rows = [*baseline_rows, quantinuum_sweep, quantinuum_width]
-        row_series = {id(row): "v0.6" for row in rows}
-        scoring_cfg = _scoring_cfg()
-        baseline_avg, _ = compute_baseline_averages_by_series(
-            rows, row_series, scoring_cfg
-        )
-
-        quantinuum = next(
-            record
-            for record in compute_device_composite_scores(
-                rows, row_series, baseline_avg, scoring_cfg
-            )
-            if record["device"] == "H2-2"
-        )
-
-        self.assertNotIn(
-            "QFT (legacy 4–12 sweep):score", quantinuum["components"]
-        )
-        self.assertEqual(quantinuum["components"]["QFT-4:score"]["raw"], 0.9)
-
-    def test_widest_legacy_sweep_wins_and_uses_its_full_baseline(self):
-        baseline_values = {4: 0.8, 8: 0.4, 12: 0.2, 16: 0.1, 20: 0.05}
-        baseline_rows = [
-            _row("ibm_torino", width, value, legacy=True)
-            for width, value in baseline_values.items()
-        ]
-        full_sweep = _aggregate_row(
-            "legacy-device",
-            20,
-            0.5,
-            provider="origin",
-            timestamp="2026-01-01T00:00:01",
-        )
-        newer_partial_sweep = _aggregate_row(
-            "legacy-device",
-            12,
-            0.9,
-            provider="origin",
-            timestamp="2026-01-02T00:00:01",
-        )
-        rows = [*baseline_rows, full_sweep, newer_partial_sweep]
-        row_series = {id(row): "v0.6" for row in rows}
-        scoring_cfg = _scoring_cfg()
-        baseline_avg, _ = compute_baseline_averages_by_series(
-            rows, row_series, scoring_cfg
-        )
-
-        record = next(
-            record
-            for record in compute_device_composite_scores(
-                rows, row_series, baseline_avg, scoring_cfg
-            )
-            if record["device"] == "legacy-device"
-        )
-        component = record["components"]["QFT (legacy 4–20 sweep):score"]
-        expected_baseline = sum(baseline_values.values()) / 5
-
-        self.assertNotIn("QFT (legacy 4–12 sweep):score", record["components"])
-        self.assertAlmostEqual(component["normalized"], 100.0 * 0.5 / expected_baseline)
-        self.assertAlmostEqual(component["coverage"], 1.0)
-        self.assertEqual(component["required_num_qubits"], 20)
-
     def test_published_qft_panels_follow_the_score_definition(self):
         with (ROOT / "scripts" / "scoring.json").open(encoding="utf-8") as f:
             scoring_cfg = json.load(f)
-
-        validate_scoring_config(scoring_cfg)
 
         for block_name in ("default", "v1.0"):
             block = (
@@ -396,28 +200,6 @@ class QFTCompositeTests(unittest.TestCase):
                 [_parse_weight(child["weight"]) for child in qft_group["components"]],
                 WEIGHTS,
             )
-            self.assertEqual(
-                [
-                    fallback["selector"]
-                    for fallback in qft_group["aggregate_fallbacks"]
-                ],
-                [
-                    {"min_qubits": 4, "max_qubits": 12, "skip_qubits": 4},
-                    {"min_qubits": 4, "max_qubits": 20, "skip_qubits": 4},
-                ],
-            )
-            self.assertEqual(
-                [fallback["covers"] for fallback in qft_group["aggregate_fallbacks"]],
-                [
-                    ["QFT-4:score", "QFT-8:score", "QFT-12:score"],
-                    [
-                        "QFT-4:score",
-                        "QFT-8:score",
-                        "QFT-12:score",
-                        "QFT-20:score",
-                    ],
-                ],
-            )
 
         legacy_qft_group = next(
             group
@@ -426,54 +208,6 @@ class QFTCompositeTests(unittest.TestCase):
         )
         self.assertEqual(len(legacy_qft_group["components"]), 1)
         self.assertNotIn("selector", legacy_qft_group["components"][0])
-
-
-class AggregateFallbackValidationTests(unittest.TestCase):
-    def test_covered_components_must_reference_group_children(self):
-        scoring_cfg = _scoring_cfg()
-        scoring_cfg["default"]["composite"]["components"][0][
-            "aggregate_fallbacks"
-        ][0]["covers"] = ["not-a-child"]
-
-        with self.assertRaisesRegex(ValueError, "Invalid covered components"):
-            validate_scoring_config(scoring_cfg)
-
-    def test_baseline_component_weights_must_sum_to_one(self):
-        scoring_cfg = _scoring_cfg()
-        scoring_cfg["default"]["composite"]["components"][0][
-            "aggregate_fallbacks"
-        ][0]["baseline_components"][0]["weight"] = "1/2"
-
-        with self.assertRaisesRegex(
-            ValueError, "Baseline component weights must sum to 1.0"
-        ):
-            validate_scoring_config(scoring_cfg)
-
-    def test_overlapping_fallbacks_for_one_metric_are_rejected_at_runtime(self):
-        scoring_cfg = _scoring_cfg()
-        fallbacks = scoring_cfg["default"]["composite"]["components"][0][
-            "aggregate_fallbacks"
-        ]
-        overlapping = json.loads(json.dumps(fallbacks[0]))
-        overlapping["selector"] = {"min_qubits": 4}
-        overlapping["label"] = "overlapping aggregate"
-        fallbacks.append(overlapping)
-
-        baseline_rows = [
-            _row("ibm_torino", width, value, legacy=True)
-            for width, value in zip(WIDTHS, [0.808, 0.215, 0.002, 0.0])
-        ]
-        aggregate_row = _aggregate_row("H2-2", 12, 0.967)
-        rows = [*baseline_rows, aggregate_row]
-        row_series = {id(row): "v0.6" for row in rows}
-        baseline_avg, _ = compute_baseline_averages_by_series(
-            rows, row_series, scoring_cfg
-        )
-
-        with self.assertRaisesRegex(ValueError, "Ambiguous aggregate fallbacks"):
-            compute_and_attach_metriq_scores(
-                rows, row_series, baseline_avg, scoring_cfg
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- score QFT from the canonical 4, 8, 12, and 20-qubit panel with weights 1/11, 2/11, 3/11, and 5/11
- support current num_qubits records and legacy fixed-width min_qubits/max_qubits records through config-driven selector alternatives
- keep the scoring engine benchmark- and suite-version-agnostic
- add mixed-schema, baseline, weighting, and zero-result regression coverage

## Root cause

QFT was configured as one selectorless component. The scorer therefore chose the latest QFT row, usually the largest width and often a valid zero. The Torino baseline consequently became zero, preventing QFT normalization for every platform.

## Verification

- python -m unittest discover -s tests: 37 tests passed
- python scripts/aggregate.py: 376 rows across 20 platforms
- Torino now anchors at 100; Boston QFT is 145.98 and Miami QFT is 72.67